### PR TITLE
Almost Unified Re-Order and Rock-Breaker switch

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -1,9 +1,9 @@
 {
   "modPriorities": [
-    "tfc",
     "gtceu",
-    "kubejs",
     "minecraft",
+    "tfc",
+    "kubejs", 
     "create"
   ],
   "stoneStrata": [
@@ -26,7 +26,10 @@
     "forge:rods/{material}",
     "forge:wires/{material}",
     "forge:storage_blocks/{material}",
-    "forge:storage_blocks/raw_{material}"
+    "forge:storage_blocks/raw_{material}",
+    "forge:double_ingots/{material}",
+    "forge:double_sheets/{material}",
+    "forge:sheets/{material}"
   ],
   "materials": [
     "aeternium",

--- a/kubejs/server_scripts/constants_server.js
+++ b/kubejs/server_scripts/constants_server.js
@@ -5,6 +5,7 @@ const $Integer = Java.loadClass("java.lang.Integer")
 const $Registries = Java.loadClass("net.minecraft.core.registries.Registries")
 const $FluidHelper = Java.loadClass("com.lowdragmc.lowdraglib.side.fluid.FluidHelper")
 const [ULV, LV, MV, HV, EV, IV, LuV, ZPM, UV] = GTValues.VA
+const RockBreakerCondition = Java.loadClass('com.gregtechceu.gtceu.common.recipe.RockBreakerCondition')
 
 const tfcStone = [
   "granite",
@@ -50,4 +51,25 @@ const tfcSaplings = [
   "sycamore",
   "white_cedar",
   "willow"
+]
+
+const tfcMetal = [
+  'bismuth',
+  'bismuth_bronze',
+  'black_bronze',
+  'bronze',
+  'brass',
+  'copper',
+  'gold',
+  'nickel',
+  'rose_gold',
+  'silver',
+  'tin',
+  'zinc',
+  'sterling_silver',
+  'wrought_iron',
+  'steel',
+  'black_steel',
+  'blue_steel',
+  'red_steel'
 ]

--- a/kubejs/server_scripts/datapack/override_tfc_armour.js
+++ b/kubejs/server_scripts/datapack/override_tfc_armour.js
@@ -1,10 +1,10 @@
 let overrideTFCArmourFinalWeld = (/** @type {Internal.DataPackEventJS} */ event) => {
-    let addTFCWeldingRecipe = (inputA, inputB, teirAnvil, result, path) => {
+    let addTFCWeldingRecipe = (inputA, inputB, tierAnvil, result, path) => {
         let json = JsonIO.toObject({
           type: "tfc:welding",
           first_input: { item: inputA },
           second_input: { item: inputB },
-          tier: teirAnvil,
+          tier: tierAnvil,
           result: { item: result }
         })
         event.addJson(`tfc:recipes/welding/${path}.json`, json)

--- a/kubejs/server_scripts/datapack/override_tfc_armour.js
+++ b/kubejs/server_scripts/datapack/override_tfc_armour.js
@@ -1,0 +1,58 @@
+let overrideTFCArmourFinalWeld = (/** @type {Internal.DataPackEventJS} */ event) => {
+    let addTFCWeldingRecipe = (inputA, inputB, teirAnvil, result, path) => {
+        let json = JsonIO.toObject({
+          type: "tfc:welding",
+          first_input: { item: inputA },
+          second_input: { item: inputB },
+          tier: teirAnvil,
+          result: { item: result }
+        })
+        event.addJson(`tfc:recipes/welding/${path}.json`, json)
+    }
+
+    //Bismuth Bronze
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/bismuth_bronze', 'gtceu:bismuth_bronze_plate', 1, 'tfc:metal/helmet/bismuth_bronze', 'bismuth_bronze_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/bismuth_bronze', 'gtceu:bismuth_bronze_plate', 1, 'tfc:metal/chestplate/bismuth_bronze', 'bismuth_bronze_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/bismuth_bronze', 'gtceu:bismuth_bronze_plate', 1, 'tfc:metal/greaves/bismuth_bronze', 'bismuth_bronze_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/bismuth_bronze', 'gtceu:bismuth_bronze_plate', 1, 'tfc:metal/boots/bismuth_bronze', 'bismuth_bronze_boots')
+    //Black Bronze
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/black_bronze', 'gtceu:black_bronze_plate', 1, 'tfc:metal/helmet/black_bronze', 'black_bronze_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/black_bronze', 'gtceu:black_bronze_plate', 1, 'tfc:metal/chestplate/black_bronze', 'black_bronze_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/black_bronze', 'gtceu:black_bronze_plate', 1, 'tfc:metal/greaves/black_bronze', 'black_bronze_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/black_bronze', 'gtceu:black_bronze_plate', 1, 'tfc:metal/boots/black_bronze', 'black_bronze_boots')
+    //Bronze
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/bronze', 'gtceu:bronze_plate', 1, 'tfc:metal/helmet/bronze', 'bronze_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/bronze', 'gtceu:bronze_plate', 1, 'tfc:metal/chestplate/bronze', 'bronze_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/bronze', 'gtceu:bronze_plate', 1, 'tfc:metal/greaves/bronze', 'bronze_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/bronze', 'gtceu:bronze_plate', 1, 'tfc:metal/boots/bronze', 'bronze_boots')
+    //Copper
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/copper', 'gtceu:copper_plate', 0, 'tfc:metal/helmet/copper', 'copper_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/copper', 'gtceu:copper_plate', 0, 'tfc:metal/chestplate/copper', 'copper_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/copper', 'gtceu:copper_plate', 0, 'tfc:metal/greaves/copper', 'copper_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/copper', 'gtceu:copper_plate', 0, 'tfc:metal/boots/copper', 'copper_boots')
+    //Wrought Iron
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/wrought_iron', 'gtceu:wrought_iron_plate', 2, 'tfc:metal/helmet/wrought_iron', 'wrought_iron_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/wrought_iron', 'gtceu:wrought_iron_plate', 2, 'tfc:metal/chestplate/wrought_iron', 'wrought_iron_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/wrought_iron', 'gtceu:wrought_iron_plate', 2, 'tfc:metal/greaves/wrought_iron', 'wrought_iron_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/wrought_iron', 'gtceu:wrought_iron_plate', 2, 'tfc:metal/boots/wrought_iron', 'wrought_iron_boots')
+    //Steel
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/steel', 'gtceu:steel_plate', 3, 'tfc:metal/helmet/steel', 'steel_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/steel', 'gtceu:steel_plate', 3, 'tfc:metal/chestplate/steel', 'steel_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/steel', 'gtceu:steel_plate', 3, 'tfc:metal/greaves/steel', 'steel_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/steel', 'gtceu:steel_plate', 3, 'tfc:metal/boots/steel', 'steel_boots')
+    //Black Steel
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/black_steel', 'gtceu:black_steel_plate', 4, 'tfc:metal/helmet/black_steel', 'black_steel_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/black_steel', 'gtceu:black_steel_plate', 4, 'tfc:metal/chestplate/black_steel', 'black_steel_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/black_steel', 'gtceu:black_steel_plate', 4, 'tfc:metal/greaves/black_steel', 'black_steel_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/black_steel', 'gtceu:black_steel_plate', 4, 'tfc:metal/boots/black_steel', 'black_steel_boots')
+    //Blue Steel
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/blue_steel', 'gtceu:blue_steel_plate', 5, 'tfc:metal/helmet/blue_steel', 'blue_steel_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/blue_steel', 'gtceu:blue_steel_plate', 5, 'tfc:metal/chestplate/blue_steel', 'blue_steel_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/blue_steel', 'gtceu:blue_steel_plate', 5, 'tfc:metal/greaves/blue_steel', 'blue_steel_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/blue_steel', 'gtceu:blue_steel_plate', 5, 'tfc:metal/boots/blue_steel', 'blue_steel_boots')
+    //Red Steel
+        addTFCWeldingRecipe('tfc:metal/unfinished_helmet/red_steel', 'gtceu:red_steel_plate', 5, 'tfc:metal/helmet/red_steel', 'red_steel_helmet')
+        addTFCWeldingRecipe('tfc:metal/unfinished_chestplate/red_steel', 'gtceu:red_steel_plate', 5, 'tfc:metal/chestplate/red_steel', 'red_steel_chestplate')
+        addTFCWeldingRecipe('tfc:metal/unfinished_greaves/red_steel', 'gtceu:red_steel_plate', 5, 'tfc:metal/greaves/red_steel', 'red_steel_greaves')
+        addTFCWeldingRecipe('tfc:metal/unfinished_boots/red_steel', 'gtceu:red_steel_plate', 5, 'tfc:metal/boots/red_steel', 'red_steel_boots')
+}

--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -39,6 +39,7 @@ MoreJSEvents.structureAfterPlace((event) => {
 
 ServerEvents.lowPriorityData(event => {
   addGregTechIngotsToTFC(event)
+  overrideTFCArmourFinalWeld(event)
 })
 
 NetworkEvents.dataReceived("customTask", (event) => {

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -134,62 +134,14 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
 
   //Rock and Stone!
   tfcStone.forEach((therock) => {
-    event.custom({
-      type: "gtceu:rock_breaker",
-      duration: 16,
-      data: {
-        fluidA: "minecraft:lava",
-        fluidB: "minecraft:water"
-      },
-      inputs: {
-        item: [
-          {
-            content: {
-              type: "gtceu:sized",
-              "fabric:type": "gtceu:sized",
-              count: 1,
-              ingredient: {
-                item: `tfc:rock/raw/${therock}`
-              }
-            },
-            chance: 0.0,
-            tierChanceBoost: 0.0
-          }
-        ]
-      },
-      outputs: {
-        item: [
-          {
-            content: {
-              type: "gtceu:sized",
-              "fabric:type": "gtceu:sized",
-              count: 1,
-              ingredient: {
-                item: `tfc:rock/raw/${therock}`
-              }
-            },
-            chance: 1.0,
-            tierChanceBoost: 0.0
-          }
-        ]
-      },
-      tickInputs: {
-        eu: [
-          {
-            content: LV,
-            chance: 1.0,
-            tierChanceBoost: 0.0
-          }
-        ]
-      },
-      tickOutputs: {},
-      recipeConditions: [
-        {
-          type: "rock_breaker",
-          data: {}
-        }
-      ]
-    })
+    event.recipes.gtceu.rock_breaker(`loose_${stone}`)
+      .notConsumable(`tfc:rock/raw/${therock}`)
+      .itemOutputs(`tfc:rock/raw/${therock}`)
+      .duration(16)
+      .EUt(ULV)
+      ["addData(java.lang.String,java.lang.String)"]("fluidA", "minecraft:lava")
+      ["addData(java.lang.String,java.lang.String)"]("fluidB", "minecraft:water") 
+      .addCondition(RockBreakerCondition.INSTANCE)
   })
   //Railcraft Start
   event.shaped("railcraft:solid_fueled_firebox", ["BBB", "BCB", "BFB"], {

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -138,7 +138,7 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       .notConsumable(`tfc:rock/raw/${therock}`)
       .itemOutputs(`tfc:rock/raw/${therock}`)
       .duration(16)
-      .EUt(ULV)
+      .EUt(LV)
       ["addData(java.lang.String,java.lang.String)"]("fluidA", "minecraft:lava")
       ["addData(java.lang.String,java.lang.String)"]("fluidB", "minecraft:water") 
       .addCondition(RockBreakerCondition.INSTANCE)

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -51,4 +51,10 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   //Railcraft
   event.replaceInput({ id: "railcraft:water_tank_siding" }, "minecraft:slimeball", "gtceu:sticky_resin")
   event.replaceInput({ id: "railcraft:steam_locomotive" }, "railcraft:blast_furnace_bricks", "gtceu:firebricks")
+
+  //TFC
+  tfcMetal.forEach((metal) => {
+    event.replaceInput({ type: 'minecraft:crafting_shaped' }, `tfc:metal/sheet/${metal}`, `#forge:plates/${metal}`)
+    event.replaceInput({ type: 'minecraft:crafting_shaped' }, `tfc:metal/double_sheet/${metal}`, `#forge:plates/double/${metal}`)
+  })
 }

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -104,4 +104,18 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   tfcSaplings.forEach((sapling) => {
     event.add("forge:saplings", `tfc:wood/sapling/${sapling}`)
   })
+
+  tfcMetal.forEach((metal) => {
+    event.add(`forge:plates/${metal}`, `tfc:metal/sheet/${metal}`)
+    event.add(`forge:plates/double/${metal}`, `tfc:metal/double_sheet/${metal}`)
+
+    event.add(`forge:sheets/${metal}`, `gtceu:${metal}_plate`)
+    event.add(`forge:double_sheets/${metal}`, `gtceu:${metal}_double_plate`)
+  })
+
+  event.add('forge:plates/iron', 'tfc:metal/sheet/cast_iron')
+  event.add('forge:plates/double/iron', 'tfc:metal/double_sheet/cast_iron')
+
+  event.add(`forge:sheets/cast_iron`, `gtceu:iron_plate`)
+  event.add(`forge:double_sheets/cast_iron`, `gtceu:iron_double_plate`)
 }

--- a/kubejs/startup_scripts/main_startup.js
+++ b/kubejs/startup_scripts/main_startup.js
@@ -57,3 +57,7 @@ GTCEuStartupEvents.registry('gtceu:tag_prefix', event => {
 GTCEuStartupEvents.registry('gtceu:world_gen_layer', event => {
   OreGen(event)
 })
+
+GTCEuStartupEvents.registry('gtceu:material', event => {
+  registerGTCEuMaterial(event)
+})

--- a/kubejs/startup_scripts/registry/materials.js
+++ b/kubejs/startup_scripts/registry/materials.js
@@ -1,0 +1,4 @@
+let registerGTCEuMaterial = (/** @type {Registry.Material} */ event) => {
+    GTMaterials.Bismuth.addFlags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD)
+    GTMaterials.Nickel.addFlags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD)
+}


### PR DESCRIPTION
All needed changed for the AU re-order, thanks to `Len Kagamine` for helping me with the Armour Override

Rock Breaker has been switched from `event.custom( )` to using the gtceu kjs integration, as the `event.custom( )` was temperary till we could get the adding of rock breaker recipes working with the kjs integration