### PR TITLE
Fixed the TFC Alloying via. Create Mixer Recipes

### DIFF
--- a/kubejs/server_scripts/constants_server.js
+++ b/kubejs/server_scripts/constants_server.js
@@ -10,6 +10,7 @@ const $CraftingComponent = Java.loadClass("com.gregtechceu.gtceu.data.recipe.Cra
 const $TagKey = Java.loadClass("net.minecraft.tags.TagKey")
 const $Fluid = Java.loadClass("net.minecraft.world.level.material.Fluid")
 const $UnboundFluidStackJS = Java.loadClass("dev.latvian.mods.kubejs.fluid.UnboundFluidStackJS")
+const $CreateInputFluid = Java.loadClass("dev.latvian.mods.kubejs.create.CreateInputFluid")
 const $Class = Java.loadClass("java.lang.Class")
 const $ChunkProvider = Java.loadClass("net.dries007.tfc.world.chunkdata.ChunkDataProvider")
 const $ForestConfig = Java.loadClass("net.dries007.tfc.world.feature.tree.ForestConfig")

--- a/kubejs/server_scripts/recipes/tfc_heating.js
+++ b/kubejs/server_scripts/recipes/tfc_heating.js
@@ -21,10 +21,19 @@ const replaceTFCHeatingAndCasting = (/** @type {Internal.RecipesEventJS} */ even
       return oldValue % 25 ? oldValue : oldValue * 1.44
     } else return newValue
   }
+  let convertFluidToKJS = (inputFluid) => {
+    if (inputFluid instanceof $CreateInputFluid) {
+      return inputFluid.copy(inputFluid.getAmount())
+    }
+    return inputFluid
+  }
   let convertFluidsFromArray = (array) => {
+    var newVal;
     return array
       .stream()
-      .map((val) => (val instanceof $UnboundFluidStackJS ? val.setAmount(convertFluidValues(val.amount)) || val : val))
+      .map((val) => (
+        newVal = convertFluidToKJS(val),
+        newVal instanceof $UnboundFluidStackJS ? newVal.setAmount(convertFluidValues(newVal.amount)) || newVal : newVal))
       .toList()
   }
 


### PR DESCRIPTION
Originally the function didn't work for the fluid inputs because it was considered a CreateInputFluid type rather than UnboundFluidStackJS

This converts CreateInputFluid to UnboundFluidStackJS so that it updates the input amount to the correct ratios