### PR TITLE
Fixed Certane Chain recipes and Updated Plate Tags

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/chains/certusBoule.js
+++ b/kubejs/server_scripts/mods/gtceu/chains/certusBoule.js
@@ -16,30 +16,30 @@ let certusSemiconductors = (/** @type {Internal.RecipesEventJS} */ event) => {
         .itemInputs('1x gregitas:certus_dust')
         .inputFluids('gtceu:hydrochloric_acid 3000')
         .outputFluids([
-            'gtceu:trichlorocertane 1000',
+            'gregitas_core:trichlorocertane 1000',
             'gtceu:hydrogen 2000'
         ])
         .EUt(MV).duration(40)
 
     event.recipes.gtceu.chemical_reactor("dichlorocertane")
-        .inputFluids('gtceu:trichlorocertane 2000')
-        .outputFluids('gtceu:dichlorocertane 1000')
+        .inputFluids('gregitas_core:trichlorocertane 2000')
+        .outputFluids('gregitas_core:dichlorocertane 1000')
         .itemOutputs('1x gregitas_core:certus_gem')
         .EUt(MV).duration(40)
 
     event.recipes.gtceu.chemical_reactor("chlorocertane")
-        .inputFluids('gtceu:dichlorocertane 2000')
+        .inputFluids('gregitas_core:dichlorocertane 2000')
         .outputFluids([
-            'gtceu:chlorocertane 1000',
-            'gtceu:certus_tetrachloride 1000'
+            'gregitas_core:chlorocertane 1000',
+            'gregitas_core:certus_tetrachloride 1000'
         ])
         .EUt(MV).duration(40)
 
     event.recipes.gtceu.chemical_reactor("certane")
-        .inputFluids('gtceu:chlorocertane 2000')
+        .inputFluids('gregitas_core:chlorocertane 2000')
         .outputFluids([
-            'gtceu:certane 1000',
-            'gtceu:dichlorocertane 1000'
+            'gregitas_core:certane 1000',
+            'gregitas_core:dichlorocertane 1000'
         ])
         .EUt(MV).duration(40)
 
@@ -47,7 +47,7 @@ let certusSemiconductors = (/** @type {Internal.RecipesEventJS} */ event) => {
     // CIRCUIT STUFF
     event.recipes.gtceu.chemical_vapor_deposition("certus_boule")
         .itemInputs('1x gtceu:silicon_wafer')
-        .inputFluids('gtceu:certane 16000')
+        .inputFluids('gregitas_core:certane 16000')
         .itemOutputs('1x gregitas:certus_boule')
         .EUt(MV).duration(1600)
 

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -197,9 +197,9 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     event.add(`forge:plates/double/${metal}`, `tfc:metal/double_sheet/${metal}`)
 
     event.add(`forge:sheets/${metal}`, `gtceu:${metal}_plate`)
-    event.add(`forge:double_sheets/${metal}`, `gtceu:${metal}_double_plate`)
+    event.add(`forge:double_sheets/${metal}`, `gtceu:double_${metal}_plate`)
     event.add(`forge:sheets`, `gtceu:${metal}_plate`)
-    event.add(`forge:double_sheets`, `gtceu:${metal}_double_plate`)
+    event.add(`forge:double_sheets`, `gtceu:double_${metal}_plate`)
   })
 
 


### PR DESCRIPTION
Since the Certane chain was migrated from GTCEU to Gregitas_Core it was causing recipes to be non-existent and allowed certus quartz to be made from nothing in chem reactor