### PR TITLE
Fix typo on sparse structures mod

### DIFF
--- a/config/sparestructuresreforged.json
+++ b/config/sparestructuresreforged.json
@@ -1,1 +1,0 @@
-{"extraSpacingPercentage":2.0,"extraSeparationPercentage":2.0}

--- a/config/sparsetructuresreforged.json
+++ b/config/sparsetructuresreforged.json
@@ -1,0 +1,1 @@
+{"extraSpacingPercentage":2.0,"extraSeparationPercentage":2.0}


### PR DESCRIPTION
This was causing structures to be excessively common.
Funnily enough, the new file also appears to have a typo, but it truly is "sparsetructures" instead of "sparsestructures"!