### PR TITLE
Adds coke to blast furnace recipe

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -171,7 +171,7 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   event.add('tfc:copper_pieces', ["tfc:ore/small_native_copper", "tfc:ore/small_malachite", "tfc:ore/small_tetrahedrite"])
   event.add('forge:thorium', ["gtceu:raw_thorium", "thoriumreactors:thorium", "create_new_age:thorium"])
   event.add('forge:ingots/niobium', ["thoriumreactors:niob_ingot"])
-  
+
   event.add('forge:tools/saws', ["#tfc:saws"])
   event.add("forge:tools/hammers", "#tfc:hammers")
   event.add('forge:tools/knives', ["#tfc:knives"])
@@ -253,7 +253,8 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   event.remove("forge:dusts/copper", ["tfc:powder/malachite", "tfc:powder/tetrahedrite", "tfc:powder/native_copper"])
   event.add("forge:plates/aluminum", "#forge:plates/aluminium")
   event.add("forge:nuggets/aluminum", "#forge:nuggets/aluminium")
-  event.add("tfc:forge_fuel", ["gtceu:coke_gem", "gtceu:coke_block","gtceu:chipped_coke_gem","gtceu:flawed_coke_gem", 'gtceu:flawless_coke_gem', 'gtceu:exquisite_coke_gem'])
+  event.add("tfc:forge_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:chipped_coke_gem", "gtceu:flawed_coke_gem", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
+  event.add("tfc:blast_furnace_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
   event.add("forge:dusts/sulfur", "tfc:powder/sulfur")
   event.remove("forge:ingots/iron", "tfc:metal/ingot/wrought_iron")
   event.remove("forge:ingots/cast_iron", "minecraft:iron_ingot")


### PR DESCRIPTION
Adds `tfc:blast_furnace_fuel` tag to Coke, Coke Block, Flawless Coke Gem and Exquisite Coke Gem.

This allows you to put vanilla Coal and TFC Bituminous Coal into a Coke Oven and use the output for the TFC Blast Furnace. I do not know why you would use Coke Block or Flawless Coke Gem (mostly kept them because they have the Forge Fuel tag). 

This makes the TFC Blast Furnace as a more viable alternative to the GT Primitive Blast Furnace. 

I personally really like the TFC Blast Furnace over the GT one, but it is really annoying to use since it requires a huge amount of Charcoal to use. I need wood for all kinds of things, but I have stacks and stacks of vanilla coal (exploration + wither skeletons) and bituminous coal laying around unused. 