### PR TITLE
Fixes Froglights for TFC frogs

### DIFF
--- a/kubejs/data/minecraft/loot_tables/entities/magma_cube.json
+++ b/kubejs/data/minecraft/loot_tables/entities/magma_cube.json
@@ -1,0 +1,135 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:inverted",
+              "term": {
+                "condition": "minecraft:damage_source_properties",
+                "predicate": {
+                  "source_entity": {
+                    "type": "tfc:frog"
+                  }
+                }
+              }
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "slime",
+                  "size": {
+                    "min": 2
+                  }
+                }
+              }
+            }
+          ],
+          "functions": [
+            {
+              "add": false,
+              "count": {
+                "type": "minecraft:uniform",
+                "max": 1.0,
+                "min": -2.0
+              },
+              "function": "minecraft:set_count"
+            },
+            {
+              "count": {
+                "type": "minecraft:uniform",
+                "max": 1.0,
+                "min": 0.0
+              },
+              "function": "minecraft:looting_enchant"
+            }
+          ],
+          "name": "minecraft:magma_cream"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:damage_source_properties",
+              "predicate": {
+                "source_entity": {
+                  "type": "tfc:frog",
+                  "type_specific": {
+                    "type": "frog",
+                    "variant": "minecraft:warm"
+                  }
+                }
+              }
+            }
+          ],
+          "functions": [
+            {
+              "add": false,
+              "count": 1.0,
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "minecraft:pearlescent_froglight"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:damage_source_properties",
+              "predicate": {
+                "source_entity": {
+                  "type": "tfc:frog",
+                  "type_specific": {
+                    "type": "frog",
+                    "variant": "minecraft:cold"
+                  }
+                }
+              }
+            }
+          ],
+          "functions": [
+            {
+              "add": false,
+              "count": 1.0,
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "minecraft:verdant_froglight"
+        },
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:damage_source_properties",
+              "predicate": {
+                "source_entity": {
+                  "type": "tfc:frog",
+                  "type_specific": {
+                    "type": "frog",
+                    "variant": "minecraft:temperate"
+                  }
+                }
+              }
+            }
+          ],
+          "functions": [
+            {
+              "add": false,
+              "count": 1.0,
+              "function": "minecraft:set_count"
+            }
+          ],
+          "name": "minecraft:ochre_froglight"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "minecraft:entities/magma_cube"
+}


### PR DESCRIPTION
Adds froglight drops for TFC frogs. TFC frogs replace vanilla frogs in 1.20, similar to how TFC does for other mods. This restores the vanilla functionality added in 1.19 when frogs were added to allow them to drop froglights.

https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues/2641

https://discord.com/channels/254530689225981953/1202016703446253680/1208445865652658196


Commands for testing:

```
/summon tfc:frog ~ ~ ~ {variant:cold}
/summon tfc:frog ~ ~ ~ {variant:verdant}
/summon tfc:frog ~ ~ ~ {variant:warm}
/summon magma_cube ~ ~ ~ {Size:0}
```