### PR TITLE
Added a way to get vanilla froglights via GT

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -406,4 +406,22 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
         )
         .EUt(MV)
         .duration(250)
+
+    event.recipes.gtceu.chemical_vapor_deposition("gregitas:green_froglight")
+        .itemInputs('3x gtceu:zinc_dust', '3x gtceu:sulfur_dust')
+        .inputFluids('gtceu:copper 72')
+        .itemOutputs('32x minecraft:verdant_froglight')
+        .EUt(LV).duration(200)
+
+    event.recipes.gtceu.chemical_vapor_deposition("gregitas:orange_froglight")
+        .itemInputs('3x gtceu:zinc_dust', '3x gtceu:sulfur_dust')
+        .inputFluids('gtceu:manganese 72')
+        .itemOutputs('32x minecraft:ochre_froglight')
+        .EUt(LV).duration(200)
+
+    event.recipes.gtceu.chemical_vapor_deposition("gregitas:blue_froglight")
+        .itemInputs('3x gtceu:zinc_dust', '3x gtceu:sulfur_dust')
+        .inputFluids('gtceu:silver 72')
+        .itemOutputs('32x minecraft:pearlescent_froglight')
+        .EUt(LV).duration(200)
 }


### PR DESCRIPTION
This is an alternative to #179 as to balance out TFC's intent to not provide infinite light source