### PR TITLE
SFM:Manager recipe adjustment to use ore dict

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -951,11 +951,10 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     })
 
     //SFM
-    shaped("sfm:manager", ["PPP", "BVI", "CCC"], {
+    shaped("sfm:manager", ["PPP", "LVL", "CCC"], {
         P: "#forge:plates/wrought_iron",
-        B: "gtceu:basic_electronic_circuit",
+        L: "gtceu:circuits/lv",
         V: "gtceu:vacuum_tube",
-        I: "gtceu:basic_integrated_circuit",
         C: "gtceu:resin_printed_circuit_board"
     })
     shaped("8x sfm:cable", ["ppp", "bcb", "ppp"], {


### PR DESCRIPTION
Adjust SFM:Manager recipe to use ore dict lv circuits instead of specific LV circuits.