### PR TITLE
honey and brick recipe unity

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -556,6 +556,7 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       .itemOutputs(`16x tfc:wood/lumber/${sapling}`)
       .duration(40)
       .EUt(LV)
+	  
   })
 
   shaped('gtceu:treated_wood_planks', ['LL', 'LL'], {L: 'gregitas:creosote_treated_lumber'}).id('gregitas:shaped/treated_wood_planks')
@@ -964,7 +965,7 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     //SFM
     shaped("sfm:manager", ["PPP", "LVL", "CCC"], {
         P: "#forge:plates/wrought_iron",
-        L: "#gtceu:circuits/lv",
+        L: "gtceu:circuits/lv",
         V: "gtceu:vacuum_tube",
         C: "gtceu:resin_printed_circuit_board"
     })
@@ -1086,5 +1087,11 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .outputFluids(Fluid.of("gtceu:fish_oil", 50))
     .duration(60)
     .EUt(LV)
-   })
+	
+    })
+   event.recipes.kubejs.shaped("2x minecraft:moss_block" , ["PPP", "PRP","PPP"], {
+        P: "gtceu:fertilizer",
+        R: "#tfc:rock/raw",
+        
+    })
 }

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -304,7 +304,10 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "minecraft:blaze_powder"})
   event.remove({ id: "minecraft:diorite"})
   event.remove({ id: "minecraft:stone"})
-
+  event.remove({ id: "minecraft:sugar_from_honey_bottle"})
+  event.remove({ id: "minecraft:honey_bottle"})
+   event.remove({ id: "minecraft:candle"}) 
+  
   //PM
   event.remove({ id: "potionsmaster:blaze_powder"})
 

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -161,6 +161,7 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   //Firmalife
   event.replaceInput({ mod: "firmalife"}, "firmalife:metal/ingot/chromium", "gtceu:chromium_ingot" )
   event.replaceInput({ mod: "firmalife"}, "firmalife:metal/ingot/stainless_steel", "gtceu:stainless_steel_ingot" )
+  
   //Firebricks/Cokebricks etc
   event.replaceInput({ id: "gtceu:shaped/compressed_coke_clay"}, "minecraft:clay_ball", "tfc:fire_clay")
   event.replaceOutput({ id: "tfc:crafting/fire_bricks"}, "tfc:fire_bricks", "gtceu:firebricks")
@@ -172,8 +173,8 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.replaceInput({ type: "minecraft:crafting_shaped"}, "minecraft:gold_block", "#forge:double_plates/gold")
   event.replaceInput({ type: "minecraft:crafting_shaped"}, "minecraft:amethyst", "tfc:gem/amethyst")
   event.replaceInput({ type: "minecraft:crafting_shapeless"}, "minecraft:amethyst", "tfc:gem/amethyst")
-
   event.replaceInput({ type: "minecraft:crafting_shaped"}, "minecraft:amethyst_shard", "tfc:gem/amethyst")
+  
   //TFShips
   tfcShipTypes.forEach((wood) => {
     event.replaceInput({ id: `tfships:${wood}_cog`}, `tfc:wood/boat/${wood}`, `gregitas:${wood}_hull_segment`)
@@ -214,14 +215,22 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.replaceInput({ mod: "createdeco"}, "tfc:torch", "minecraft:ochre_froglight")
   event.replaceInput({ mod: "createdeco"}, "minecraft:redstone_torch", "minecraft:glowstone")
   event.replaceInput({ mod: "createdeco"}, "minecraft:glow_berries", "minecraft:verdant_froglight")
-  event.replaceInput({ mod: "createdeco"}, "minecraft:soul_torch", "minecraft:perlescent_froglight")
+  event.replaceInput({ mod: "createdeco"}, "minecraft:soul_torch", "minecraft:pearlescent_froglight")
 
   event.replaceInput({ mod: "createdeco"}, "create:brass_nugget", "#forge:nuggets/brass")
   event.replaceInput({ mod: "createdeco"}, "create:zinc_nugget", "#forge:nuggets/zinc")
   event.replaceInput({ mod: "createdeco"}, "create:copper_nugget", "#forge:nuggets/copper")
   event.replaceInput({ mod: "createdeco"}, "create:limestone", "tfc:rock/raw/limestone")
   event.replaceInput({ mod: "createdeco"}, "create:crimsite", "minecraft:netherrack")
-  event.replaceInput({ mod: "createdeco"}, "create:asurine", "#forge:storage_blocks/lapis")
-  event.replaceInput({ mod: "createdeco"}, "create:veridium", "#forge:storage_blocks/emerald")
-
+  event.replaceInput({ mod: "createdeco"}, "create:asurine", "tfc:rock/raw/dolomite")
+  event.replaceInput({ mod: "createdeco"}, "create:veridium", "tfc:rock/raw/schist")
+  event.replaceInput({ mod: "createdeco"}, "create:ochrum", "tfc:rock/raw/claystone")
+  event.replaceInput({ mod: "createdeco"}, "create:brass_block", "#forge:storage_blocks/brass")
+  event.replaceInput({ mod: "createdeco"}, "create:zinc_block", "#forge:storage_blocks/zinc")
+  event.replaceInput({}, "minecraft:honeycomb", "firmalife:beeswax")
+  event.replaceInput({}, "minecraft:honey_bottle", "firmalife:jar/honey")
+  event.replaceInput({ mod: "create"}, "minecraft:glass_bottle", "tfc:empty_jar")
+  event.replaceOutput({ mod: "create" }, "minecraft:glass_bottle", "tfc:empty_jar")
+  event.replaceOutput({ mod: "create" }, "minecraft:honey_bottle", "firmalife:jar/honey")
+  event.replaceInput({ mod: "create"}, "minecraft:honeycomb", "firmalife:beeswax")
 }


### PR DESCRIPTION
(tried) to unify honey to use beeswax/raw honey instead of honeycomb, also use jars of honey instead of bottles of honey. removed honey bottle -> sugar recipe, removed 4 bottles+honey block=1 honey block (couldnt figure out how to replace the output of the recipe with honey jars)

(create deco) made blue and verdant bricks cheaper (dolomite, schist), replaced ochrum in dean bricks recipe with claystone, fixed brass hull and zinc hull using create variants of blocks

idk how to highlight what was changed so for removal from 307-309, and replace 225-236

idk how this works but added a moss block crafting table recipe