### PR TITLE
Unify GT Salt and TFC Salt (And salt/saltpeter audit)

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -85,6 +85,8 @@
     "ruby",
     "rose_gold",
     "sapphire",
+	"salt",
+	"saltpeter",
     "signalum",
     "silver",
     "stainless_steel",

--- a/kubejs/data/firmalife/recipes/crafting/bacon.json
+++ b/kubejs/data/firmalife/recipes/crafting/bacon.json
@@ -1,0 +1,29 @@
+{
+  "__comment__": "Remove when almostunified updates to cover this recipe type",
+  "type": "tfc:damage_inputs_shapeless_crafting",
+  "recipe": {
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "type": "tfc:has_trait",
+          "trait": "firmalife:smoked",
+          "ingredient": {
+            "item": "tfc:food/pork"
+          }
+        }
+      },
+      {
+        "tag": "tfc:knives"
+      },
+      {
+        "tag": "forge:dusts/salt"
+      }
+    ],
+    "result": {
+      "item": "firmalife:food/bacon",
+      "count": 4
+    }
+  }
+}

--- a/kubejs/data/firmalife/recipes/crafting/salsa.json
+++ b/kubejs/data/firmalife/recipes/crafting/salsa.json
@@ -1,0 +1,28 @@
+{
+  "__comment__": "Remove when almostunified updates to cover this recipe type",
+  "type": "tfc:damage_inputs_shapeless_crafting",
+  "recipe": {
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "item": "tfc:food/tomato"
+        }
+      },
+      {
+        "tag": "forge:dusts/salt"
+      },
+      {
+        "item": "firmalife:plant/cilantro"
+      },
+      {
+        "tag": "tfc:knives"
+      }
+    ],
+    "result": {
+      "item": "firmalife:food/salsa",
+      "count": 5
+    }
+  }
+}

--- a/kubejs/data/firmalife/recipes/crafting/tortilla_chips.json
+++ b/kubejs/data/firmalife/recipes/crafting/tortilla_chips.json
@@ -1,0 +1,24 @@
+{
+  "__comment__": "Remove when almostunified updates to cover this recipe type",
+  "type": "tfc:damage_inputs_shapeless_crafting",
+  "recipe": {
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+      {
+        "type": "tfc:not_rotten",
+        "ingredient": {
+          "item": "firmalife:food/taco_shell"
+        }
+      },
+      {
+        "tag": "forge:dusts/salt"
+      },
+      {
+        "tag": "tfc:hammers"
+      }
+    ],
+    "result": {
+      "item": "firmalife:food/tortilla_chips"
+    }
+  }
+}

--- a/kubejs/data/tfc/recipes/barrel/fresh_to_salt_water.json
+++ b/kubejs/data/tfc/recipes/barrel/fresh_to_salt_water.json
@@ -1,0 +1,17 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "tfc:barrel_instant",
+  "input_item": {
+    "ingredient": {
+      "tag": "forge:dusts/salt"
+    }
+  },
+  "input_fluid": {
+    "ingredient": "minecraft:water",
+    "amount": 500
+  },
+  "output_fluid": {
+    "fluid": "tfc:salt_water",
+    "amount": 500
+  }
+}

--- a/kubejs/server_scripts/mods/create/createAdd.js
+++ b/kubejs/server_scripts/mods/create/createAdd.js
@@ -15,7 +15,7 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
                     tag: 'tfc:foods/dough'}
                 },
                 {
-                    item: 'tfc:powder/salt'
+                    tag: 'forge:dusts/salt'
                 },
                 {
                     item: 'firmalife:spice/basil_leaves'
@@ -103,7 +103,7 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
                     amount: 1000
                 },
                 {
-                    item: 'tfc:powder/salt'
+                    tag: 'forge:dusts/salt'
                 },
             ],
             results: [
@@ -159,7 +159,7 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
                     tag: 'firmalife:feeds_yeast'}
                 },
                 {
-                    item: 'tfc:powder/salt'
+                    tag: 'forge:dusts/salt'
                 },
             ],
             results: [

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -258,8 +258,14 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   event.add("tfc:forge_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:chipped_coke_gem", "gtceu:flawed_coke_gem", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
   event.add("tfc:blast_furnace_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
-
+  
   event.add("forge:dusts/sulfur", "tfc:powder/sulfur")
+  
+  event.remove("forge:dusts/salt", "railcraft:saltpeter_dust")
+  event.add("forge:dusts/salt", "tfc:powder/salt")
+  event.add("forge:dusts/saltpeter", "tfc:powder/saltpeter")
+  event.add("forge:dusts/saltpeter", "railcraft:saltpeter_dust")
+  
   event.remove("forge:ingots/iron", "tfc:metal/ingot/wrought_iron")
   event.remove("forge:ingots/cast_iron", "minecraft:iron_ingot")
 


### PR DESCRIPTION
- Unifies GTCEU Salt Dust and TerraFirmaCraft Salt.
- Rebalances the TFC Saltwater in barrel recipe to use the GTCEU amounts (500mB water + 1 salt dust -> 500mB salt water)
- Unifies GTCEU Saltpeter, Railcraft Reborn saltpeter, and TFC Saltpeter.
- Re-tags Railcraft saltpeter which was mistakenly called "salt"

Issues:
1. TFC Salt still spawns in-world as the salt lick blocks. Could further unify with KubeJS or something but I decided to hold off for now as it's a large change compared to how much it actually impacts. TFC Salt should be interchangeable with the GTCEU Salt dust for all recipes anyway but still needs comprehensive testing.
2. Did not touch the 2x salt + sulfur + charcoal gunpowder recipe, but it's really odd to do this with NaCl salt.
3. Allows for infinite TFC salt starting from GTCEU LV era via centrifuge, may introduce a balance issue.

Future plans:
Maybe I'll unify the TFC Sylvite (useless atm outside of dyes, but still generates in worldgen) with GTCEU's "Rock Salt", which is actually Potassium Chloride (Sylvite IRL).