### PR TITLE
Fix HPCA recipe

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -854,6 +854,28 @@ event.recipes.create.pressing("gtceu:wrought_iron_plate", ["#forge:ingots/wrough
     duration: 6000
   }).id('gregitas:barrel/creosote_treated_lumber')
 
+  //Assembly Line
+  event.recipes.gtceu.assembly_line("hpca")
+  .itemInputs(
+    "gtceu:data_bank",
+    "4x #gtceu:circuits/zpm",
+    "8x gtceu:luv_field_generator",
+    "gtceu:data_orb",
+    "gtceu:computer_monitor_cover",
+    "32x gtceu:uranium_rhodium_dinaquadide_double_wire",
+    "32x gtceu:uranium_rhodium_dinaquadide_double_wire",
+    "16x gtceu:normal_optical_pipe",
+  )
+  .inputFluids(
+    "gtceu:soldering_alloy 1152",
+    "gtceu:vanadium_gallium 1152",
+    "gtceu:pcb_coolant 4000",
+  )
+  .itemOutputs("gtceu:high_performance_computation_array")
+  ["scannerResearch(java.util.function.UnaryOperator)"](b => b.researchStack('gtceu:computer_monitor_cover').EUt(IV).duration(2400))
+  .duration(1200)
+  .EUt(100000)
+
   //GTCEU End
   //Computercraft
   shaped('computercraft:computer_normal', ['sps', 'scs', 'OPO'], {

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -48,6 +48,7 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "gtceu:extractor/seed_oil_from_pumpkin"})
   event.remove({ id: "gtceu:electric_blast_furnace/steel_from_wrought_iron"})
   event.remove({ id: "gtceu:electric_blast_furnace/steel_from_iron"})
+  event.remove({ id: "gtceu:assembly_line/high_performance_computing_array"})
 
   //GT / Railcraft Tool Specific
   toolsToRemove.forEach((tool) => {


### PR DESCRIPTION
See also related post in discord forum:
[HPCA recipe is broken due to reduced stack size](https://discord.com/channels/254530689225981953/1290385510023299222/1290385510023299222)

Basically HPCA recipe requires 64 wires to be stored in a single ULV input bus, which is impossible due to wire stack size reduced to 32.
This changes the recipe to 2 stacks of 32 wires so it can be crafted.

Currently blocking the progression because anything later in zpm/uv requires a functional research station.