### PR TITLE
Fix recipes for ultimate battery and computercraft stuff

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -876,6 +876,33 @@ event.recipes.create.pressing("gtceu:wrought_iron_plate", ["#forge:ingots/wrough
   .duration(1200)
   .EUt(100000)
 
+  event.recipes.gtceu.assembly_line("uhv_battery")
+  .itemInputs(
+    "16x gtceu:double_darmstadtium_plate",
+    "4x gtceu:wetware_processor_mainframe",
+    "16x gtceu:energy_cluster",
+    "4x gtceu:uv_field_generator",
+    "64x gtceu:uhpic_wafer",
+    "64x gtceu:uhpic_wafer",
+    "64x gtceu:advanced_smd_diode",
+    "64x gtceu:advanced_smd_capacitor",
+    "64x gtceu:advanced_smd_resistor",
+    "64x gtceu:advanced_smd_transistor",
+    "64x gtceu:advanced_smd_inductor",
+    "32x gtceu:enriched_naquadah_trinium_europium_duranide_single_wire",
+    "32x gtceu:enriched_naquadah_trinium_europium_duranide_single_wire",
+    "64x gtceu:neutronium_bolt",
+  )
+  .inputFluids(
+    "gtceu:soldering_alloy 5760",
+    "gtceu:polybenzimidazole 2304",
+    "gtceu:naquadria 2592",
+  )
+  .itemOutputs("gtceu:max_battery")
+  .stationResearch(b => b.researchStack('gtceu:energy_cluster').EUt(1966080).CWUt(144, 576000))
+  .duration(2000)
+  .EUt(300000)
+
   //GTCEU End
   //Computercraft
   shaped('computercraft:computer_normal', ['sps', 'scs', 'OPO'], {

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -49,6 +49,7 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "gtceu:electric_blast_furnace/steel_from_wrought_iron"})
   event.remove({ id: "gtceu:electric_blast_furnace/steel_from_iron"})
   event.remove({ id: "gtceu:assembly_line/high_performance_computing_array"})
+  event.remove({ id: "gtceu:assembly_line/ultimate_battery"})
 
   //GT / Railcraft Tool Specific
   toolsToRemove.forEach((tool) => {

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -202,7 +202,7 @@ event.replaceInput({id: "woodencog:crushing/milling_raw_quartzite" }, "tfc:rock/
   event.replaceOutput({ id: `/^gtceu:smelting\/smelt_.*_ore_to_ingot/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")
   event.replaceOutput({ id: `/^gtceu:blasting\/smelt_.*_ore_to_ingot/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")
   event.replaceOutput({ id: `/^minecraft:iron_ingot_from_.*/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")
-  event.replaceInput({ mod: "computercraft"}, "minecraft:redstone", "gtceu:basic_electronic_circuit")
+  event.replaceInput({ mod: "computercraft"}, "minecraft:redstone", "#gtceu:circuits/lv")
 
   event.replaceInput({ mod: "immersiveengineering"}, "#forge:rods/aluminum", "gtceu:aluminium_rod")
 


### PR DESCRIPTION
This changes:
- Fixes wire stack limit for ultimate battery recipe (from 64 to 2x 32)
- Allow some computer recipes to accept any LV circuits instead of only `Basic Electronic Circuit` (It doesn't make sense when recipes like Computer already accept any LV circuits)

PS.
Is it okay to remove a recipe in removal.js and add it back with the same recipe id in add.js?
I'm not sure if that's a safe thing to do so I changed the recipe id from `ultimate_battery` to `uhv_battery`.