### PR TITLE
Fix Turbine Glass recipe

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -1370,8 +1370,7 @@ event.recipes.gtceu.assembler('thoriumreactors:thermal_controller')
 event.recipes.gtceu.assembler('thoriumreactors:turbine_glass')
   .itemInputs(
     'thoriumreactors:turbine_casing',
-    '2x immersiveengineering:insulating_glass',
-    '2x gtceu:reactorglass'
+    '2x immersiveengineering:insulating_glass'
   )
   .itemOutputs(
     '2x thoriumreactors:turbine_glass'


### PR DESCRIPTION
Removes the requirement for gtceu:reactorglass and syncs it with the recipe shown in JEI