### PR TITLE
fix: support tfc compost in scguns composter

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -302,4 +302,24 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   //Thorium Reactors
   event.removeAllTagsFrom('thoriumreactors:fluorite')
+
+  // Scorched Guns
+  const weakCompostables = [
+    event.get("tfc:compost_greens_low"),
+    event.get("tfc:compost_browns_low")
+  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds());
+
+  const normalCompostables = [
+    event.get("tfc:compost_greens"),
+    event.get("tfc:compost_browns")
+  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds());
+
+  const strongCompostables = [
+    event.get("tfc:compost_greens_high"),
+    event.get("tfc:compost_browns_high")
+  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds());
+
+  weakCompostables.forEach(c => event.add("scguns:weak_compost", c));
+  normalCompostables.forEach(c => event.add("scguns:normal_compost", c));
+  strongCompostables.forEach(c => event.add("scguns:strong_compost", c));
 }


### PR DESCRIPTION
The Scorched Guns 2 Advanced Composter should, but did not support all of the TFC compostable materials. This fix ensures that this is the case. The TFC compost levels are directly converted into the scguns compost levels. TFC high browns/greens are turned into scguns strong, TFC low browns/greens into scguns weak, etc.

![image](https://github.com/user-attachments/assets/0c21d2f6-3e3d-44eb-ac83-47e614d6b56b)
