### PR TITLE
feat: tag wood chips as wood dust

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -355,4 +355,7 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   weakCompostables.forEach(c => event.add("scguns:weak_compost", c));
   normalCompostables.forEach(c => event.add("scguns:normal_compost", c));
   strongCompostables.forEach(c => event.add("scguns:strong_compost", c));
+
+  event.add("forge:dusts", "createdieselgenerators:wood_chip");
+  event.add("forge:dusts/wood", "createdieselgenerators:wood_chip");
 }


### PR DESCRIPTION
Create Diesel Generator's adds a Wood Chips item. This is in essence, wood dust, though it is not tagged as such. This change set adds the appropriate tags to it.