### PR TITLE
feat: ore-dicting create drill mods quartz dust with gtceu quartz sand

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -358,4 +358,7 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   event.add("forge:dusts", "createdieselgenerators:wood_chip");
   event.add("forge:dusts/wood", "createdieselgenerators:wood_chip");
+
+  event.add("forge:dusts/nether_quartz", "createmoredrillheads:quartz_dusts");
+  event.add("forge:dusts/quartz", "gtceu:quartz_sand_dust");
 }


### PR DESCRIPTION
The Create: More Drill Heads mod adds its own quartz dust. This quartz dust is tagged with forge:dusts/quartz, but not forge:dusts/nether_quartz which is what gtceu expects. This PR ensures that both dusts are tagged with the same tags.