### PR TITLE
feat: ore-dict cinder-flour as netherrack dust

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -2689,4 +2689,7 @@ event.recipes.kubejs.shaped("scguns:disc_mold" , ["W  ", " M ","   "], {
   W: "#forge:tools/wire_cutters",
   M: "scguns:blank_mold"
 })
+
+  event.replaceInput({ input: "minecraft:netherrack" }, "minecraft:netherrack", "#forge:netherrack");
+  event.replaceInput({ input: "create:cinder_flour" }, "create:cinder_flour", "#forge:dusts/netherrack");
 }

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -358,4 +358,8 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   event.add("forge:dusts", "createdieselgenerators:wood_chip");
   event.add("forge:dusts/wood", "createdieselgenerators:wood_chip");
+
+  event.add("forge:netherrack", "beneath:cobblerack");
+  event.add("forge:dusts", "create:cinder_flour");
+  event.add("forge:dusts/netherrack", "create:cinder_flour");
 }


### PR DESCRIPTION
Here we are modifying all recipes that directly use minecraft:netherrack to use #forge:netherrack, and tagging create:cinder_flour with #forge:dusts/netherrack