### PR TITLE
fix: replace the vanilla gravel quest reward from railcraft tank quest

### DIFF
--- a/config/ftbquests/quests/chapters/railcraft.snbt
+++ b/config/ftbquests/quests/chapters/railcraft.snbt
@@ -292,7 +292,7 @@
 			rewards: [{
 				count: 32
 				id: "288486493DF95B3F"
-				item: "minecraft:gravel"
+				item: "tfc:rock/gravel/andesite"
 				type: "item"
 			}]
 			tasks: [{


### PR DESCRIPTION
This PR ensures that the user is not given vanilla gravel as a quest reward, and is instead given a tfc gravel.