### PR TITLE
fix: make clayline quest return tfc diorite

### DIFF
--- a/config/ftbquests/quests/chapters/medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/medium_voltage.snbt
@@ -812,7 +812,7 @@
 			optional: true
 			rewards: [{
 				id: "32792BF84A213FBF"
-				item: "minecraft:diorite"
+				item: "tfc:rock/raw/diorite"
 				type: "item"
 			}]
 			subtitle: "Passive aluminium"


### PR DESCRIPTION
This is a fix for: https://discord.com/channels/254530689225981953/1303089174420914216