### PR TITLE
feat: added crusher recipe for mossy cobbles

### DIFF
--- a/kubejs/server_scripts/mods/create/createAdd.js
+++ b/kubejs/server_scripts/mods/create/createAdd.js
@@ -559,6 +559,14 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
             event.recipes.create.milling(`tfc:rock/gravel/${type.stone}`, `tfc:rock/cobble/${type.stone}`, 250)
     })
 
+    tfcCobbleToSand.forEach((type) => {
+        event.recipes.create.crushing([
+            `tfc:rock/gravel/${type.stone}`,
+            Item.of('gtceu:plant_ball').withChance(0.2),
+            ],
+            `tfc:rock/mossy_cobble/${type.stone}` , 250)
+    });
+
     event.recipes.create.splashing(Item.of('minecraft:clay_ball').withChance(0.25), '#forge:sand', 250)
 
     event.recipes.create.milling('gregitas_core:igneous_dust', '#tfc:igneous_extrusive_rock', 250)


### PR DESCRIPTION
This PR adds the ability to crush mossy cobble down to gravel, and 20% change of a plant ball. The 20% is a halfway point in between the 30% of a grass block, and 12.5% of a dirt block.

![image](https://github.com/user-attachments/assets/22c22bdd-8be9-401b-85c7-d60e644a23e6)
