### PR TITLE
feat: add coke tags to gt coke for create crushing

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -378,4 +378,8 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   event.add("gregitas_core:apple", "minecraft:apple");
   event.add("gregitas_core:apple", "tfc:food/green_apple");
   event.add("gregitas_core:apple", "tfc:food/red_apple");
+
+  event.add("forge:coal_coke", "gtceu:coke_dust");
+  event.add("forge:coal_coke", "gtceu:coke_gem");
+  event.add("forge:storage_blocks/coal_coke", "gtceu:coke_block");
 }


### PR DESCRIPTION
Add forge coal coke tags to gt coke to be able to grind it into graphite