### PR TITLE
fix: disable charcoal pile igniter, and treated iron bucket recipes

### DIFF
--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -527,4 +527,7 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   
   event.remove({id: "scguns:pebbles_from_gravel"})
   event.remove({id: "minecraft:bamboo_planks"})
+
+  event.remove({ id: "gtceu:shaped/charcoal_pile_igniter"});
+  event.remove({ id: "scguns:treated_iron/treated_iron_bucket"});
 }


### PR DESCRIPTION
This disables the charcoal pile igniter which is currently broken due to needing vanilla dirt, and logs. It also goes against the TFC charcoal process so it is being disabled.

![image](https://github.com/user-attachments/assets/e99f5e9a-d109-4c2a-a91b-66989c5ab2c2)

Additionally this PR also disables the treated iron bucket recipe which is an unintended technology skip as it allows you to craft a bucket without getting a GT bender.