### PR TITLE
fix: remove tfc tuyere dupe

### DIFF
--- a/kubejs/server_scripts/recipes/tfc_heating.js
+++ b/kubejs/server_scripts/recipes/tfc_heating.js
@@ -49,6 +49,7 @@ const replaceTFCHeatingAndCasting = (/** @type {Internal.RecipesEventJS} */ even
     fluid.setAmount(r.getId().includes("bars") ? convertFluidValues(fluid.amount) / 2 : convertFluidValues(fluid.amount))
     
     fluid.setAmount(r.getId().includes("block") ? convertFluidValues(fluid.amount) / 2 : convertFluidValues(fluid.amount))
+    fluid.setAmount(r.getId().includes("tuyere") ? convertFluidValues(fluid.amount) / 2 : convertFluidValues(fluid.amount))
 
     r.resultFluid(fluid)
   })


### PR DESCRIPTION
Currently players can craft plates via a bender or create press, and then craft a double plate from that. They then take the double plate (which only cost two ingots), and craft a tuyere which can then be melted down for four ingots. This PR adds the tuyere to the list of items that have their outputs halved.