### PR TITLE
feat: added railcraft tanks quests

### DIFF
--- a/config/ftbquests/quests/chapters/railcraft.snbt
+++ b/config/ftbquests/quests/chapters/railcraft.snbt
@@ -303,7 +303,7 @@
 			}]
 			title: "{gravitas.quest.railcraft.crusher}"
 			x: 7.0d
-			y: 2.0d
+			y: 2.5d
 		}
 		{
 			dependencies: ["0938DBC3D637DC56"]
@@ -323,7 +323,7 @@
 			}]
 			title: "{gravitas.quest.railcraft.water_tank}"
 			x: 7.0d
-			y: 1.0d
+			y: 0.5d
 		}
 		{
 			dependencies: ["302C27B3E947EC2F"]
@@ -1276,6 +1276,83 @@
 			}]
 			x: 0.0d
 			y: 1.0d
+		}
+		{
+			dependencies: ["0938DBC3D637DC56"]
+			description: ["{gravitas.quest.railcraft.desc.iron_tank}"]
+			id: "7A3376F81D32B5D3"
+			rewards: [{
+				count: 8
+				id: "2F2E6FE2EFD6D1FA"
+				item: "minecraft:iron_ingot"
+				type: "item"
+			}]
+			tasks: [
+				{
+					count: 2L
+					id: "0F15DDD5F1AAE2B4"
+					item: "railcraft:white_iron_tank_valve"
+					type: "item"
+				}
+				{
+					count: 24L
+					id: "5DEE182FA00AF451"
+					item: { Count: 30, id: "railcraft:white_iron_tank_wall" }
+					type: "item"
+				}
+				{
+					count: 8L
+					id: "46F1EB9DBCA02019"
+					item: { Count: 8, id: "railcraft:white_iron_tank_gauge" }
+					type: "item"
+				}
+			]
+			title: "{gravitas.quest.railcraft.iron_tank}"
+			x: 7.5d
+			y: 1.5d
+		}
+		{
+			dependencies: ["7A3376F81D32B5D3"]
+			description: ["{gravitas.quest.railcraft.desc.steel_tank}"]
+			id: "7F14661940C61C57"
+			rewards: [{
+				count: 8
+				id: "03A37D694E45BE74"
+				item: {
+					Count: 1
+					ForgeCaps: {
+						"tfc:item_heat": {
+							heat: 0.0f
+							ticks: 0L
+						}
+					}
+					id: "gtceu:steel_ingot"
+				}
+				type: "item"
+			}]
+			tasks: [
+				{
+					count: 2L
+					id: "61B3F330C162B5D7"
+					item: "railcraft:white_steel_tank_valve"
+					type: "item"
+				}
+				{
+					count: 24L
+					id: "71250FC3CA8BE153"
+					item: { Count: 24, id: "railcraft:white_steel_tank_wall" }
+					type: "item"
+				}
+				{
+					count: 8L
+					id: "21361B24502526AC"
+					item: { Count: 8, id: "railcraft:white_steel_tank_gauge" }
+					type: "item"
+				}
+			]
+			title: "{gravitas.quest.railcraft.steel_tank}"
+			x: 8.5d
+			y: 1.5d
 		}
 	]
 	title: "{gravitas.chapters.28.title}"

--- a/kubejs/assets/gravitas/lang/en_us.json
+++ b/kubejs/assets/gravitas/lang/en_us.json
@@ -899,6 +899,8 @@
 	"gravitas.quest.railcraft.crusher": "Crusher",
 	"gravitas.quest.railcraft.manual_roller": "Manual Rolling Machine",
 	"gravitas.quest.railcraft.powered_roller": "Powered Rolling Machine",
+	"gravitas.quest.railcraft.iron_tank":"Iron Tanks", 
+	"gravitas.quest.railcraft.steel_tank":"Steel Tanks",
 
 	"gravitas.quest.railcraft.desc.rail": "RailCraft is the perfect mod for transportation or just those who hyperfocus on trains! A great place to start is with the normal Minecraft rails.",
 	"gravitas.quest.railcraft.desc.types_tracks": "In RailCraft normal rails won't suffice for everything. You're gonna need new better rails!",
@@ -951,7 +953,8 @@
 	"gravitas.quest.railcraft.desc.crusher": "The Crusher is just as the name suggests. It can crush blocks to get the crafting materials, like bricks from a brick staircase, or dusts from ingots. It needs power to work though! To build one it's 3x2x2 of Crusher blocks.",
 	"gravitas.quest.railcraft.desc.manual_roller": "The Manual Rolling Machine will be your little crafting machine for many things material for railcraft! When you put the recipe in and it can make more than 1 it will autocraft while you're still looking at it. When you leave the Rolling Machine while crafting it will abort the crafting and put it in your inventory. You must manually build the last recipe!",
 	"gravitas.quest.railcraft.desc.powered_roller": "The Powered Rolling Machine is much better version of the Manual Rolling Machine. You don't have to keep looking in the machine to craft things and it will automatically craft all of them. The only problem is it needs power!",
-
+	"gravitas.quest.railcraft.desc.iron_tank":"While GregTech drums and Create copper tanks provide compact storage, they fall short when it comes to scalability and capacity. Railcraft Iron Tanks, on the other hand, take fluid storage to an industrial level.\n\nA 3x4x3 can store 576 buckets of fluid, which should be plenty for all of your early game needs.",
+	"gravitas.quest.railcraft.desc.steel_tank": "The Steel Tank is identical to the Iron Tank, but it can hold twice as much.",
 
 	"gravitas.shop.requirement.walk.1": "Walked 20,000 blocks",
 	"gravitas.shop.requirement.ride_horse.1": "Traveled by Horse for 40,000 blocks",


### PR DESCRIPTION
This PR adds two new quests to the railcraft chapter. Both quests are for the railcraft multiblock iron tank, and steel tank respectively. The completion of the iron tank quest returns 8 iron ingots, while the steel tank quest returns 8 steel ingots. The reward is a bit arbitrary, but I opted to give some raw resources back that went into the construction of the tanks.