### PR TITLE
feat/biodiesel

### DIFF
--- a/kubejs/server_scripts/tags/fluid_tags.js
+++ b/kubejs/server_scripts/tags/fluid_tags.js
@@ -1,69 +1,86 @@
 const addFluidTags = (/** @type {TagEvent.Fluid} */ event) => {
-    event.add('tfc:usable_in_tool_head_mold', [
-            'gtceu:aluminium',
-            'gtceu:titanium',
-            'gtceu:invar',
-            'tfc:metal/sterling_silver',
-            'tfc:metal/rose_gold',
-            'firmalife:metal/stainless_steel',
-            'gtceu:damascus_steel',
-            'gtceu:cobalt_brass'
-        ]
-    )
-    event.add('tfc:usable_in_wooden_bucket', [
-        'gregitas:raw_syrup',
-        'gregitas:maple_syrup',
-        'gregitas:raw_resin',
-        'gtceu:creosote',
-        'gtceu:rubber'
-    ]
-    )
-    event.add('tfc:usable_in_barrel', [
-        'gregitas:raw_syrup',
-        'gregitas:maple_syrup',
-        'gregitas:raw_resin',
-        'gtceu:creosote'
-   ]
-   )
-    event.add('tfc:usable_in_pot', [
-        'gregitas:raw_syrup',
-        'gregitas:maple_syrup',
-        'gregitas:raw_resin'
-   ]
-   )
-   event.add('tfc:usable_in_jug', [
-       'gregitas:maple_syrup'
-   ]
-   )
-   event.add('tfc:usable_in_ingot_mold',
+    event.add("tfc:usable_in_tool_head_mold", [
+        "gtceu:aluminium",
+        "gtceu:titanium",
+        "gtceu:invar",
+        "tfc:metal/sterling_silver",
+        "tfc:metal/rose_gold",
+        "firmalife:metal/stainless_steel",
+        "gtceu:damascus_steel",
+        "gtceu:cobalt_brass"
+    ])
+
+    event.add("tfc:usable_in_wooden_bucket", [
+        "gregitas:raw_syrup",
+        "gregitas:maple_syrup",
+        "gregitas:raw_resin",
+        "gtceu:creosote",
+        "gtceu:rubber"
+    ])
+
+    event.add("tfc:usable_in_barrel", [
+        "gregitas:raw_syrup",
+        "gregitas:maple_syrup",
+        "gregitas:raw_resin",
+        "gtceu:creosote"
+    ])
+
+    event.add("tfc:usable_in_pot", [
+        "gregitas:raw_syrup",
+        "gregitas:maple_syrup",
+        "gregitas:raw_resin"
+    ])
+
+    event.add("tfc:usable_in_jug", [
+        "gregitas:maple_syrup"
+    ])
+
+    event.add("tfc:usable_in_ingot_mold",
         [
-            'gtceu:tin',
-            'gtceu:silver',
-            'gtceu:gold',
-            'gtceu:copper',
-            'gtceu:nickel',
-            'gtceu:bismuth',
-            'gtceu:rubber',
-            'gregitas_core:igneous_alloy',
+            "gtceu:tin",
+            "gtceu:silver",
+            "gtceu:gold",
+            "gtceu:copper",
+            "gtceu:nickel",
+            "gtceu:bismuth",
+            "gtceu:rubber",
+            "gregitas_core:igneous_alloy",
         ]
     )
+
     gtceuIngots1.forEach(id => {
-        event.add('tfc:usable_in_ingot_mold', `gtceu:${id}`)
+        event.add("tfc:usable_in_ingot_mold", `gtceu:${id}`)
     })
 
-    event.add('forge:salt_water', 'tfc:salt_water')
-    
+    event.add("forge:salt_water", "tfc:salt_water")
+
     tfcMetalFluids.forEach(fluid => {
         event.add(`forge:${fluid}`, `tfc:metal/${fluid}`)
     })
 
-    event.add('create:bottomless/allow', 'tfc:salt_water')
-    event.add('create:bottomless/allow', 'tfc:river_water')
+    event.add("create:bottomless/allow", "tfc:salt_water")
+    event.add("create:bottomless/allow", "tfc:river_water")
 
     event.add("forge:water", "tfc:river_water")
-    event.add('gregitas:water', "minecraft:water")
+    event.add("gregitas:water", "minecraft:water")
 
-    event.add('forge:crude_oil', 'gtceu:oil_medium')
-    event.add('forge:diesel', 'gtceu:diesel')
-    event.add('forge:bio_diesel', 'gtceu:bio_diesel')
+    event.add("forge:crude_oil", "gtceu:oil_medium")
+    event.add("forge:diesel", "gtceu:diesel")
+    event.add("forge:bio_diesel", "gtceu:bio_diesel")
+    event.add("forge:bio_diesel", "createdieselgenerators:biodiesel")
+    event.add("forge:bio_diesel", "immersiveengineering:biodiesel")
+
+    const plantTags = ["forge:plant_oil", "forge:seed_oil"];
+    const plantFluids = [
+        "immersiveengineering:plantoil",
+        "createdieselgenerators:plant_oil",
+        "createaddition:seed_oil",
+        "gtceu:seed_oil",
+    ];
+
+    plantTags.forEach(tag => {
+        plantFluids.forEach(fluid => {
+            event.add(tag, fluid);
+        })
+    })
 }


### PR DESCRIPTION
This PR ensures that plant oil, and seed oil are treated the same. Both are created through the exact same mechanisms, crushing seeds (or specific plants in IE though IE's mechanism for getting seed oil is currently disabled).

It also combines bio-diesels.

It also replaces the single quotes with double quotes as double quotes are used more commonly in the codebase.

It also formats the file.