### PR TITLE
feat: added tree-tap support for menril resin

### DIFF
--- a/kubejs/data/treetap/recipes/menril_resin.json
+++ b/kubejs/data/treetap/recipes/menril_resin.json
@@ -1,0 +1,23 @@
+{
+  "type": "treetap:tap_extract",
+  "log": {
+    "item": "integrateddynamics:menril_log"
+  },
+  "processing_time": 12000,
+  "metal_result": {
+    "item": "integrateddynamics:bucket_menril_resin"
+  },
+  "wooden_result": {
+    "item": "tfc:wooden_bucket",
+    "nbt": "{fluid: {FluidName: \"integrateddynamics:bucket_menril_resin\", Amount: 1000}}"
+  },
+  "life_cycle": [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+  "collect_bucket": true,
+  "fluid_color": "#57B3D1",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "integrateddynamics"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for tapping menril resin from menril trees. The schedule, and rate is identical to the kapok tree resin tapping.