### PR TITLE
chore: clean up menril resin

### DIFF
--- a/kubejs/data/treetap/recipes/menril_resin_from_menril_log.json
+++ b/kubejs/data/treetap/recipes/menril_resin_from_menril_log.json
@@ -3,7 +3,7 @@
   "log": {
     "item": "integrateddynamics:menril_log"
   },
-  "processing_time": 12000,
+  "processing_time": 9600,
   "metal_result": {
     "item": "integrateddynamics:bucket_menril_resin"
   },
@@ -11,7 +11,7 @@
     "item": "tfc:wooden_bucket",
     "nbt": "{fluid: {FluidName: \"integrateddynamics:bucket_menril_resin\", Amount: 1000}}"
   },
-  "life_cycle": [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+  "life_cycle": [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0],
   "collect_bucket": true,
   "fluid_color": "#57B3D1",
   "conditions": [

--- a/kubejs/data/treetap/recipes/menril_resin_from_menril_log_filled.json
+++ b/kubejs/data/treetap/recipes/menril_resin_from_menril_log_filled.json
@@ -1,0 +1,23 @@
+{
+  "type": "treetap:tap_extract",
+  "log": {
+    "item": "integrateddynamics:menril_log_filled"
+  },
+  "processing_time": 7200,
+  "metal_result": {
+    "item": "integrateddynamics:bucket_menril_resin"
+  },
+  "wooden_result": {
+    "item": "tfc:wooden_bucket",
+    "nbt": "{fluid: {FluidName: \"integrateddynamics:bucket_menril_resin\", Amount: 1000}}"
+  },
+  "life_cycle": [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0],
+  "collect_bucket": true,
+  "fluid_color": "#57B3D1",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "integrateddynamics"
+    }
+  ]
+}

--- a/kubejs/server_scripts/tags/block_tags.js
+++ b/kubejs/server_scripts/tags/block_tags.js
@@ -214,5 +214,5 @@ const addBlockTags = (/** @type {TagEvent.Block} */ event) => {
   event.add("forge:ores/kaolin",["tfc:white_kaolin_clay", "tfc:kaolin_clay_grass", "tfc:pink_kaolin_clay", "tfc:red_kaolin_clay"])
 
   event.add("tfc:toughness_3", ["gtceu:steel_frame"])
-  
+  event.add("treetap:tappable", ["integrateddynamics:menril_log", "integrateddynamics:menril_log_filled"])
 }

--- a/kubejs/server_scripts/tags/fluid_tags.js
+++ b/kubejs/server_scripts/tags/fluid_tags.js
@@ -15,7 +15,8 @@ const addFluidTags = (/** @type {TagEvent.Fluid} */ event) => {
         "gregitas:maple_syrup",
         "gregitas:raw_resin",
         "gtceu:creosote",
-        "gtceu:rubber"
+        "gtceu:rubber",
+        "integrateddynamics:menril_resin"
     ])
 
     event.add("tfc:usable_in_barrel", [


### PR DESCRIPTION
This PR does a bit more work on the menril resin tree tap work. I added support for filled logs. 

One thing to note is that these changes here (and in the last resin PR) don't fully work until I get a PR merged over in the treetap mod

Right now the recipe exists in NEI, but the tap just isn't attachable to a menril log