### PR TITLE
feat: add olive oil as a plant oil

### DIFF
--- a/kubejs/server_scripts/tags/fluid_tags.js
+++ b/kubejs/server_scripts/tags/fluid_tags.js
@@ -76,6 +76,7 @@ const addFluidTags = (/** @type {TagEvent.Fluid} */ event) => {
         "createdieselgenerators:plant_oil",
         "createaddition:seed_oil",
         "gtceu:seed_oil",
+        "tfc:olive_oil"
     ];
 
     plantTags.forEach(tag => {


### PR DESCRIPTION
This allows olive oil to be used as a plant oil when interacting with non-tfc mods.