### PR TITLE
feat: allow for greenhouse to have air instead of sapling

### DIFF
--- a/kubejs/startup_scripts/registry/machines.js
+++ b/kubejs/startup_scripts/registry/machines.js
@@ -86,6 +86,7 @@ let registerMachines = (/** @type {Registry.Machine} */ event) => {
                 .or(Predicates.blocks("tfc:wood/sapling/sycamore"))
                 .or(Predicates.blocks("tfc:wood/sapling/white_cedar"))
                 .or(Predicates.blocks("tfc:wood/sapling/willow"))
+                .or(Predicates.air())
             )
             .where("G", Predicates.blocks("ae2:quartz_glass"))
             .build())


### PR DESCRIPTION
This change allows for air to be used in addition to saplings for the center of a greenhouse. This means that this change is fully backwards compatable.