### PR TITLE
feat: add nether tree resins

### DIFF
--- a/kubejs/data/treetap/recipes/crimson_resin_from_crimson_log.json
+++ b/kubejs/data/treetap/recipes/crimson_resin_from_crimson_log.json
@@ -1,0 +1,13 @@
+{
+  "type": "treetap:tap_extract",
+  "log": {
+    "item": "beneath:wood/log/crimson"
+  },
+  "processing_time": 9600,
+  "metal_result": {
+    "item": "gregitas:crimson_resin_bucket"
+  },
+  "life_cycle": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  "collect_bucket": true,
+  "fluid_color": "#B62A0C"
+}

--- a/kubejs/data/treetap/recipes/warped_resin_from_warped_log.json
+++ b/kubejs/data/treetap/recipes/warped_resin_from_warped_log.json
@@ -1,0 +1,13 @@
+{
+  "type": "treetap:tap_extract",
+  "log": {
+    "item": "beneath:wood/log/warped"
+  },
+  "processing_time": 9600,
+  "metal_result": {
+    "item": "gregitas:warped_resin_bucket"
+  },
+  "life_cycle": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  "collect_bucket": true,
+  "fluid_color": "#000F75"
+}

--- a/kubejs/startup_scripts/registry/fluids.js
+++ b/kubejs/startup_scripts/registry/fluids.js
@@ -1,25 +1,31 @@
 // priority 10
 
 let registerFluids = (/** @type {Registry.Fluid} */ event) => {
-
     event.create('gregitas:raw_syrup')
-    .thinTexture(0xBB9351)
-    .displayName('Raw Maple Sap')
+        .thinTexture(0xBB9351)
+        .displayName('Raw Maple Sap')
 
     event.create('gregitas:maple_syrup')
-    .thickTexture(0xBB9351)
-    .displayName('Maple Syrup')
+        .thickTexture(0xBB9351)
+        .displayName('Maple Syrup')
 
     event.create("gregitas:cane_syrup")
-    .thickTexture(0xB67050)
-    .displayName("Cane Syrup")
+        .thickTexture(0xB67050)
+        .displayName("Cane Syrup")
 
     event.create("gregitas:sugar_syrup")
-    .thickTexture(0xFFF9DB)
-    .displayName("Sugar Syrup")
+        .thickTexture(0xFFF9DB)
+        .displayName("Sugar Syrup")
 
     event.create("gregitas:raw_resin")
-    .thickTexture(0x785808)
-    .displayName("Raw Resin")
+        .thickTexture(0x785808)
+        .displayName("Raw Resin")
 
+    event.create("gregitas:crimson_resin")
+        .thickTexture(0xB62A0C)
+        .displayName("Crimson Resin")
+
+    event.create("gregitas:warped_resin")
+        .thickTexture(0x000F75)
+        .displayName("Warped Resin")
 }


### PR DESCRIPTION
This PR adds both crimson resin, and warped resin. They are both extracted from their respective nether tree. 

This PR does not contain any uses of said resin, that will come in a follow up PR.