### PR TITLE
fix: correcting saltpeter type in salt or seaweed quest

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
@@ -644,7 +644,7 @@
 						items: [
 							{
 								Count: 1b
-								id: "gtceu:saltpeter_ore"
+								id: "gtceu:raw_saltpeter"
 							}
 							{
 								Count: 1b


### PR DESCRIPTION
The wrong saltpeter was being used.