### PR TITLE
feat: added brewery recipes for tfc green compostables

### DIFF
--- a/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens.json
+++ b/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens.json
@@ -1,0 +1,67 @@
+{
+    "type": "gtceu:brewery",
+    "duration": 160,
+    "inputs": {
+        "item": [
+            {
+                "content": {
+                    "type": "gtceu:sized",
+                    "count": 1,
+                    "ingredient": {
+                        "tag": "tfc:compost_greens"
+                    }
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ],
+        "fluid": [
+            {
+                "content": {
+                    "amount": 20,
+                    "value": [
+                        {
+                            "tag": "forge:water"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "outputs": {
+        "fluid": [
+            {
+                "content": {
+                    "amount": 20,
+                    "value": [
+                        {
+                            "fluid": "gtceu:biomass"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickInputs": {
+        "eu": [
+            {
+                "content": 3,
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickOutputs": {},
+    "inputChanceLogics": {},
+    "outputChanceLogics": {},
+    "tickInputChanceLogics": {},
+    "tickOutputChanceLogics": {}
+}

--- a/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens_high.json
+++ b/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens_high.json
@@ -1,0 +1,67 @@
+{
+    "type": "gtceu:brewery",
+    "duration": 160,
+    "inputs": {
+        "item": [
+            {
+                "content": {
+                    "type": "gtceu:sized",
+                    "count": 1,
+                    "ingredient": {
+                        "tag": "tfc:compost_greens_high"
+                    }
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ],
+        "fluid": [
+            {
+                "content": {
+                    "amount": 100,
+                    "value": [
+                        {
+                            "tag": "forge:water"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "outputs": {
+        "fluid": [
+            {
+                "content": {
+                    "amount": 100,
+                    "value": [
+                        {
+                            "fluid": "gtceu:biomass"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickInputs": {
+        "eu": [
+            {
+                "content": 3,
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickOutputs": {},
+    "inputChanceLogics": {},
+    "outputChanceLogics": {},
+    "tickInputChanceLogics": {},
+    "tickOutputChanceLogics": {}
+}

--- a/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens_low.json
+++ b/kubejs/data/gtceu/recipes/brewery/tfc_compost_greens_low.json
@@ -1,0 +1,67 @@
+{
+    "type": "gtceu:brewery",
+    "duration": 160,
+    "inputs": {
+        "item": [
+            {
+                "content": {
+                    "type": "gtceu:sized",
+                    "count": 1,
+                    "ingredient": {
+                        "tag": "tfc:compost_greens_low"
+                    }
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ],
+        "fluid": [
+            {
+                "content": {
+                    "amount": 20,
+                    "value": [
+                        {
+                            "tag": "forge:water"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "outputs": {
+        "fluid": [
+            {
+                "content": {
+                    "amount": 20,
+                    "value": [
+                        {
+                            "fluid": "gtceu:biomass"
+                        }
+                    ]
+                },
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickInputs": {
+        "eu": [
+            {
+                "content": 3,
+                "chance": 10000,
+                "maxChance": 10000,
+                "tierChanceBoost": 0
+            }
+        ]
+    },
+    "tickOutputs": {},
+    "inputChanceLogics": {},
+    "outputChanceLogics": {},
+    "tickInputChanceLogics": {},
+    "tickOutputChanceLogics": {}
+}


### PR DESCRIPTION
This PR allows for tfc compostable to be used in the brewery for biomass. Weak compost produces equivalent to the smallest pre-existing biomass recipe, while high produces the equivalent of the largest existing biomass recipe.