### PR TITLE
feat: support all chisels in chisel quest

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschaptersnew2title.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschaptersnew2title.snbt
@@ -409,37 +409,10 @@
 			tasks: [{
 				id: "38B8B02C44957784"
 				item: {
-					Count: 1
-					id: "itemfilters:or"
+                    Count: 1
+					id: "itemfilters:tag"
 					tag: {
-						items: [
-							{
-								Count: 1b
-								ForgeCaps: {
-									"tfc:item_heat": {
-										heat: 0.0f
-										ticks: 0L
-									}
-								}
-								id: "tfc:metal/chisel/copper"
-								tag: {
-									Damage: 0
-								}
-							}
-							{
-								Count: 1b
-								ForgeCaps: {
-									"tfc:item_heat": {
-										heat: 0.0f
-										ticks: 0L
-									}
-								}
-								id: "tfc:metal/chisel/bronze"
-								tag: {
-									Damage: 0
-								}
-							}
-						]
+						value: "tfc:chisels"
 					}
 				}
 				title: "{gravitas.quest.stage2.chisel}"


### PR DESCRIPTION
This PR just ensures that the chisel quest supports all tagged chisels, not just copper and vanilla bronze (this is primarily to support stuff like black bronze chisels).