### PR TITLE
feat: tag scguns phsophor as phosphorus

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -133,57 +133,41 @@ let tfcSaplingz = [
 ]
 
 let tfcMetalz = [
-  'bismuth',
-  'bismuth_bronze',
-  'black_bronze',
-  'bronze',
-  'brass',
-  'copper',
-  'gold',
-  'nickel',
-  'rose_gold',
-  'silver',
-  'tin',
-  'zinc',
-  'sterling_silver',
-  'wrought_iron',
-  'steel',
-  'black_steel',
-  'blue_steel',
-  'red_steel',
-  'chromite',
-  'thorium',
-  'tungsten_carbide',
-  'damascus_steel',
-  'tungsten_steel',
-  'cobalt_brass',
-  'vanadium_steel',
-  'ultimet',
-  'invar',
-  'aluminium',
-  'titanium'
-]
-const fire = [
-  "red",
-  "green",
+  "bismuth",
+  "bismuth_bronze",
+  "black_bronze",
   "bronze",
-  "gray"
-]
-const ice = [
-  "blue",
-  "white",
-  "sapphire",
-  "silver"
-]
-const lightning = [
-  "electric",
-  "amethyst",
+  "brass",
   "copper",
-  "black"
+  "gold",
+  "nickel",
+  "rose_gold",
+  "silver",
+  "tin",
+  "zinc",
+  "sterling_silver",
+  "wrought_iron",
+  "steel",
+  "black_steel",
+  "blue_steel",
+  "red_steel",
+  "chromite",
+  "thorium",
+  "tungsten_carbide",
+  "damascus_steel",
+  "tungsten_steel",
+  "cobalt_brass",
+  "vanadium_steel",
+  "ultimet",
+  "invar",
+  "aluminium",
+  "titanium"
 ]
+const fire = ["red", "green", "bronze", "gray"]
+const ice = ["blue", "white", "sapphire", "silver"]
+const lightning = ["electric", "amethyst", "copper", "black"]
 
 const addItemTags = (/** @type {TagEvent.Item} */ event) => {
-
   fire.forEach((color) => {
     event.add("gregitas:eggs/dragon/fire", `iceandfire:dragonegg_${color}`)
   })
@@ -196,13 +180,17 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   event.add("gravitas:igneous_rocks", ["#tfc:igneous_extrusive_rock", "#tfc:igneous_intrusive_rock"])
   event.add("forge:dusts/diamond", "tfc:powder/diamond")
-  event.add('tfc:copper_pieces', ["tfc:ore/small_native_copper", "tfc:ore/small_malachite", "tfc:ore/small_tetrahedrite"])
-  event.add('forge:thorium', ["gtceu:raw_thorium", "thoriumreactors:thorium", "create_new_age:thorium"])
-  event.add('forge:ingots/niobium', ["thoriumreactors:niob_ingot"])
+  event.add("tfc:copper_pieces", [
+    "tfc:ore/small_native_copper",
+    "tfc:ore/small_malachite",
+    "tfc:ore/small_tetrahedrite"
+  ])
+  event.add("forge:thorium", ["gtceu:raw_thorium", "thoriumreactors:thorium", "create_new_age:thorium"])
+  event.add("forge:ingots/niobium", ["thoriumreactors:niob_ingot"])
 
-  event.add('forge:tools/saws', ["#tfc:saws"])
+  event.add("forge:tools/saws", ["#tfc:saws"])
   event.add("forge:tools/hammers", "#tfc:hammers")
-  event.add('forge:tools/knives', ["#tfc:knives"])
+  event.add("forge:tools/knives", ["#tfc:knives"])
 
   event.add("forge:tools", ["#forge:tools/saws", "#forge:tools/hammers", "#forge:tools/knives", "#forge:tools/files"])
 
@@ -219,7 +207,7 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   tfcSaplingz.forEach((sapling) => {
     event.add("forge:saplings", `tfc:wood/sapling/${sapling}`)
-    event.add('minecraft:logs_that_burn', [`#tfc:${sapling}_logs`])
+    event.add("minecraft:logs_that_burn", [`#tfc:${sapling}_logs`])
   })
 
   tfcMetalz.forEach((metal) => {
@@ -232,48 +220,67 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     event.add(`forge:double_sheets`, `gtceu:double_${metal}_plate`)
   })
 
-
-
   event.add("firmalife:sweetener", "#tfc:sweetener")
   event.add("forge:treated_wood", "firmalife:treated_wood")
 
-  event.add('tfc:any_knapping', ['minecraft:flint', 'gtceu:rubber_plate', 'gtceu:polyethylene_plate', 'gtceu:polytetrafluoroethylene_plate', 'gtceu:polybenzimidazole_plate'])
-  event.add('tfc:flint_knapping', 'minecraft:flint')
-  event.add('tfc:rubber_knapping', ['gtceu:rubber_plate', 'gtceu:polyethylene_plate', 'gtceu:polytetrafluoroethylene_plate', 'gtceu:polybenzimidazole_plate'])
+  event.add("tfc:any_knapping", [
+    "minecraft:flint",
+    "gtceu:rubber_plate",
+    "gtceu:polyethylene_plate",
+    "gtceu:polytetrafluoroethylene_plate",
+    "gtceu:polybenzimidazole_plate"
+  ])
+  event.add("tfc:flint_knapping", "minecraft:flint")
+  event.add("tfc:rubber_knapping", [
+    "gtceu:rubber_plate",
+    "gtceu:polyethylene_plate",
+    "gtceu:polytetrafluoroethylene_plate",
+    "gtceu:polybenzimidazole_plate"
+  ])
 
-  GTMaterialRegistry.registeredMaterials.forEach(id => {
-      event.add('tfc:saws', `${id}_saw`)
-      event.add('tfc:hammers', `${id}_hammer`)
-      event.add('tfc:knives', `${id}_knife`)
-      event.add('tfc:usable_on_tool_rack',`${id}_file`)
-      event.add('tfc:usable_on_tool_rack',`${id}_wrench`)
-      event.add('tfc:usable_on_tool_rack',`${id}_saw`)
-      event.add('tfc:usable_on_tool_rack',`${id}_plunger`)
-      event.add('tfc:usable_on_tool_rack',`${id}_hammer`)
-      event.add('tfc:usable_on_tool_rack',`${id}_knife`)
-      event.add('tfc:usable_on_tool_rack',`${id}_screwdriver`)
-      event.add('tfc:usable_on_tool_rack',`${id}_crowbar`)
-      event.add('tfc:usable_on_tool_rack',`${id}_mortar`)
-      event.add('tfc:usable_on_tool_rack',`${id}_soft_mallet`)
-      event.add('tfc:usable_on_tool_rack',`${id}_wire_cutter`)
-      event.add('tfc:usable_on_tool_rack',`${id}_sword`)
-      event.add('tfc:usable_on_tool_rack',`${id}_pickaxe`)
-      event.add('tfc:usable_on_tool_rack',`${id}_axe`)
-      event.add('tfc:usable_on_tool_rack',`${id}_shovel`)
-      event.add('tfc:usable_on_tool_rack',`${id}_spade`)
-      event.add('tfc:usable_on_tool_rack',`${id}_hoe`)
-      event.add('tfc:usable_on_tool_rack',`${id}_scythe`)
-      event.add('tfc:usable_on_tool_rack',`${id}_butchery_knife`)
+  GTMaterialRegistry.registeredMaterials.forEach((id) => {
+    event.add("tfc:saws", `${id}_saw`)
+    event.add("tfc:hammers", `${id}_hammer`)
+    event.add("tfc:knives", `${id}_knife`)
+    event.add("tfc:usable_on_tool_rack", `${id}_file`)
+    event.add("tfc:usable_on_tool_rack", `${id}_wrench`)
+    event.add("tfc:usable_on_tool_rack", `${id}_saw`)
+    event.add("tfc:usable_on_tool_rack", `${id}_plunger`)
+    event.add("tfc:usable_on_tool_rack", `${id}_hammer`)
+    event.add("tfc:usable_on_tool_rack", `${id}_knife`)
+    event.add("tfc:usable_on_tool_rack", `${id}_screwdriver`)
+    event.add("tfc:usable_on_tool_rack", `${id}_crowbar`)
+    event.add("tfc:usable_on_tool_rack", `${id}_mortar`)
+    event.add("tfc:usable_on_tool_rack", `${id}_soft_mallet`)
+    event.add("tfc:usable_on_tool_rack", `${id}_wire_cutter`)
+    event.add("tfc:usable_on_tool_rack", `${id}_sword`)
+    event.add("tfc:usable_on_tool_rack", `${id}_pickaxe`)
+    event.add("tfc:usable_on_tool_rack", `${id}_axe`)
+    event.add("tfc:usable_on_tool_rack", `${id}_shovel`)
+    event.add("tfc:usable_on_tool_rack", `${id}_spade`)
+    event.add("tfc:usable_on_tool_rack", `${id}_hoe`)
+    event.add("tfc:usable_on_tool_rack", `${id}_scythe`)
+    event.add("tfc:usable_on_tool_rack", `${id}_butchery_knife`)
   })
 
   gtceuToolsGT.forEach((metal) => {
-    event.add('forge:double_ingots', `gregitas:double_${metal.id}_ingot`)
+    event.add("forge:double_ingots", `gregitas:double_${metal.id}_ingot`)
     event.add(`forge:double_ingots/${metal.id}`, `gregitas:double_${metal.id}_ingot`)
   })
 
   event.add("tfc:pickaxe_tier6", ["tfc:metal/pickaxe/red_steel", "tfc:metal/pickaxe/blue_steel"])
-  event.add("tfc:castable_pickaxe_heads", ["tfc:metal/pickaxe_head/copper", "tfc:metal/pickaxe_head/bronze", "tfc:metal/pickaxe_head/black_bronze", "tfc:metal/pickaxe_head/bismuth_bronze"])
-  event.add("tfc:castable_propick_heads", ["tfc:metal/propick_head/copper", "tfc:metal/propick_head/bronze", "tfc:metal/propick_head/black_bronze", "tfc:metal/propick_head/bismuth_bronze"])
+  event.add("tfc:castable_pickaxe_heads", [
+    "tfc:metal/pickaxe_head/copper",
+    "tfc:metal/pickaxe_head/bronze",
+    "tfc:metal/pickaxe_head/black_bronze",
+    "tfc:metal/pickaxe_head/bismuth_bronze"
+  ])
+  event.add("tfc:castable_propick_heads", [
+    "tfc:metal/propick_head/copper",
+    "tfc:metal/propick_head/bronze",
+    "tfc:metal/propick_head/black_bronze",
+    "tfc:metal/propick_head/bismuth_bronze"
+  ])
   event.get("smallships:cogs").removeAll()
   tfcSaplingz.forEach((wood) => {
     event.add("smallships:cogs", `tfships:${wood}_cog`)
@@ -284,42 +291,57 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   event.add("forge:plates/aluminum", "#forge:plates/aluminium")
   event.add("forge:nuggets/aluminum", "#forge:nuggets/aluminium")
 
-  event.add("tfc:forge_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
-  event.add("tfc:blast_furnace_fuel", ["gtceu:coke_gem", "gtceu:coke_block", "gtceu:flawless_coke_gem", "gtceu:exquisite_coke_gem"])
-  
+  event.add("tfc:forge_fuel", [
+    "gtceu:coke_gem",
+    "gtceu:coke_block",
+    "gtceu:flawless_coke_gem",
+    "gtceu:exquisite_coke_gem"
+  ])
+  event.add("tfc:blast_furnace_fuel", [
+    "gtceu:coke_gem",
+    "gtceu:coke_block",
+    "gtceu:flawless_coke_gem",
+    "gtceu:exquisite_coke_gem"
+  ])
+
   event.add("forge:dusts/sulfur", "tfc:powder/sulfur")
-  
+
   event.remove("forge:dusts/salt", "railcraft:saltpeter_dust")
   event.add("forge:dusts/salt", "tfc:powder/salt")
   event.add("forge:dusts/saltpeter", "tfc:powder/saltpeter")
   event.add("forge:dusts/saltpeter", "railcraft:saltpeter_dust")
-  
+
   event.remove("forge:ingots/iron", "tfc:metal/ingot/wrought_iron")
   event.remove("forge:ingots/cast_iron", "minecraft:iron_ingot")
-
 
   event.remove("tfc:unfired_pottery", "woodencog:unfired_fireclay_crucible")
   //WOODENCLOG
   event.remove("forge:plates/obsidian", "tfc:metal/sheet/steel")
-  event.remove("forge:plates/iron","tfc:metal/sheet/wrought_iron")
-  event.add('tfc:usable_on_tool_rack',
-    [
-      'mininggadgets:mininggadget',
-      'mininggadgets:mininggadget_fancy',
-      'mininggadgets:mininggadget_simple',
-      'create:wrench',
-      'buildinggadgets2:gadget_building',
-      'buildinggadgets2:gadget_exchanging',
-      'buildinggadgets2:gadget_copy_paste',
-      'buildinggadgets2:gadget_cut_paste',
-      'buildinggadgets2:gadget_destruction',
-      'expatternprovider:fishbig',
-      '#forge:tools',
-      'enderio:dark_steel_sword'
-    ]
-  )
-  event.add("forge:double_ingots/any_bronze", ["tfc:metal/double_ingot/bronze","tfc:metal/double_ingot/bismuth_bronze", "tfc:metal/double_ingot/black_bronze"])
-  event.add("forge:plates/any_bronze", ["#forge:plates/bronze","#forge:plates/bismuth_bronze", "#forge:plates/black_bronze"])
+  event.remove("forge:plates/iron", "tfc:metal/sheet/wrought_iron")
+  event.add("tfc:usable_on_tool_rack", [
+    "mininggadgets:mininggadget",
+    "mininggadgets:mininggadget_fancy",
+    "mininggadgets:mininggadget_simple",
+    "create:wrench",
+    "buildinggadgets2:gadget_building",
+    "buildinggadgets2:gadget_exchanging",
+    "buildinggadgets2:gadget_copy_paste",
+    "buildinggadgets2:gadget_cut_paste",
+    "buildinggadgets2:gadget_destruction",
+    "expatternprovider:fishbig",
+    "#forge:tools",
+    "enderio:dark_steel_sword"
+  ])
+  event.add("forge:double_ingots/any_bronze", [
+    "tfc:metal/double_ingot/bronze",
+    "tfc:metal/double_ingot/bismuth_bronze",
+    "tfc:metal/double_ingot/black_bronze"
+  ])
+  event.add("forge:plates/any_bronze", [
+    "#forge:plates/bronze",
+    "#forge:plates/bismuth_bronze",
+    "#forge:plates/black_bronze"
+  ])
   event.add("iceandfire:tempt_hippogryph", ["tfc:food/rabbit", "tfc:food/cooked_rabbit"])
   event.add("iceandfire:tempt_hippocampus", ["tfc:plant/winged_kelp", "tfc:plant/leafy_kelp"])
   event.add("iceandfire:heal_hippocampus", ["tfc:plant/giant_kelp_flower"])
@@ -327,61 +349,55 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
   event.add("forge:raw_materials/graphite", ["tfc:ore/graphite"])
   event.add("minecraft:axes", ["#tfc:axes"])
   event.add("forge:ingots/aluminum", ["gtceu:aluminium_ingot"])
-  event.add("forge:rods/aluminium", ["vintageimprovements:aluminum_rod","alltheores:aluminum_rod"])
- 
+  event.add("forge:rods/aluminium", ["vintageimprovements:aluminum_rod", "alltheores:aluminum_rod"])
+
   event.removeAllTagsFrom("immersiveengineering:storage_steel")
-  
+
   event.add("tfc:glassworking_potash", ["gtceu:saltpeter_dust"])
 
   event.add("scguns:advanced_bullet_material", "gtceu:steel_ingot")
- 
-  event.add("forge:dusts/saltpeter","scguns:niter_dust")
 
-  const weakCompostables = [
-    event.get("tfc:compost_greens_low"),
-    event.get("tfc:compost_browns_low")
-  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds())
+  event.add("forge:dusts/saltpeter", "scguns:niter_dust")
 
-  const normalCompostables = [
-    event.get("tfc:compost_greens"),
-    event.get("tfc:compost_browns")
-  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds())
+  const weakCompostables = [event.get("tfc:compost_greens_low"), event.get("tfc:compost_browns_low")]
+    .reduce((arr, iter) => arr.concat(iter), [])
+    .map((i) => i.getObjectIds())
 
-  const strongCompostables = [
-    event.get("tfc:compost_greens_high"),
-    event.get("tfc:compost_browns_high")
-  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds())
+  const normalCompostables = [event.get("tfc:compost_greens"), event.get("tfc:compost_browns")]
+    .reduce((arr, iter) => arr.concat(iter), [])
+    .map((i) => i.getObjectIds())
 
-  weakCompostables.forEach(c => event.add("scguns:weak_compost", c))
-  normalCompostables.forEach(c => event.add("scguns:normal_compost", c))
-  strongCompostables.forEach(c => event.add("scguns:strong_compost", c))
+  const strongCompostables = [event.get("tfc:compost_greens_high"), event.get("tfc:compost_browns_high")]
+    .reduce((arr, iter) => arr.concat(iter), [])
+    .map((i) => i.getObjectIds())
+
+  weakCompostables.forEach((c) => event.add("scguns:weak_compost", c))
+  normalCompostables.forEach((c) => event.add("scguns:normal_compost", c))
+  strongCompostables.forEach((c) => event.add("scguns:strong_compost", c))
 
   event.add("forge:dusts", "createdieselgenerators:wood_chip")
   event.add("forge:dusts/wood", "createdieselgenerators:wood_chip")
-
 
   event.add("forge:dusts/nether_quartz", "createmoredrillheads:quartz_dusts")
   event.add("forge:dusts/quartz", "gtceu:quartz_sand_dust")
   event.add("forge:netherrack", "beneath:cobblerack")
   event.add("forge:dusts", "create:cinder_flour")
   event.add("forge:dusts/netherrack", "create:cinder_flour")
-  
-  const tfcFermentables = [
-    event.get("tfc:foods/fruits"),
-    event.get("tfc:foods/grains"),
-  ].reduce((arr, iter) => arr.concat(iter), []).map(i => i.getObjectIds());
-  tfcFermentables.forEach(c => event.add("forge:fermentable", c))
-  
+
+  const tfcFermentables = [event.get("tfc:foods/fruits"), event.get("tfc:foods/grains")]
+    .reduce((arr, iter) => arr.concat(iter), [])
+    .map((i) => i.getObjectIds())
+  tfcFermentables.forEach((c) => event.add("forge:fermentable", c))
+
   event.add("forge:fermentable", "tfc:food/potato")
 
+  event.add("gregitas_core:apple", "minecraft:apple")
+  event.add("gregitas_core:apple", "tfc:food/green_apple")
+  event.add("gregitas_core:apple", "tfc:food/red_apple")
 
-  event.add("gregitas_core:apple", "minecraft:apple");
-  event.add("gregitas_core:apple", "tfc:food/green_apple");
-  event.add("gregitas_core:apple", "tfc:food/red_apple");
-
-  event.add("forge:coal_coke", "gtceu:coke_dust");
-  event.add("forge:coal_coke", "gtceu:coke_gem");
-  event.add("forge:storage_blocks/coal_coke", "gtceu:coke_block");
+  event.add("forge:coal_coke", "gtceu:coke_dust")
+  event.add("forge:coal_coke", "gtceu:coke_gem")
+  event.add("forge:storage_blocks/coal_coke", "gtceu:coke_block")
 
   const tfcCoral = [
     "tube",
@@ -401,15 +417,17 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     "horn_dead_coral",
     "horn_coral",
     "horn_dead_coral_fan",
-    "horn_coral_fan",
-  ];
-  
-  tfcCoral.forEach(coral => {
-    event.add("create:upgrade_aquatic/coral", `tfc:coral/${coral}`);
-  });
+    "horn_coral_fan"
+  ]
+
+  tfcCoral.forEach((coral) => {
+    event.add("create:upgrade_aquatic/coral", `tfc:coral/${coral}`)
+  })
 
   event.add("forge:dusts/apatite", "tfcthermaldeposits:mineral/powder/apatite")
 
   event.add("gravitas:phantom", "minecraft:warped_fungus")
   event.add("gravitas:phantom", "beneath:wood/sapling/warped")
+
+  event.add("forge:dusts/phosphorus", "scguns:phosphor_dust")
 }


### PR DESCRIPTION
Phosphor and Phosphorus are not the same thing, however I think its just a naming issue over in scguns (Phosphor just glows, and isn't useful in a firearm themed mod)

This PR tags the scguns phosphor as phosphorus, and additionally lints the file containing the changes.

