### PR TITLE
feat: added tfc welding recipes for gregitas double ingots

### DIFF
--- a/kubejs/data/tfc/recipes/welding/cobalt_brass_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/cobalt_brass_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:cobalt_brass_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:cobalt_brass_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_cobalt_brass_ingot"
+    }
+}

--- a/kubejs/data/tfc/recipes/welding/damascus_steel_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/damascus_steel_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:damascus_steel_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:damascus_steel_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_damascus_steel_ingot"
+    }
+}

--- a/kubejs/data/tfc/recipes/welding/tungsten_carbide_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/tungsten_carbide_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:tungsten_carbide_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:tungsten_carbide_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_tungsten_carbide_ingot"
+    }
+}

--- a/kubejs/data/tfc/recipes/welding/tungsten_steel_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/tungsten_steel_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:vanadium_steel_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:vanadium_steel_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_vanadium_steel_ingot"
+    }
+}

--- a/kubejs/data/tfc/recipes/welding/ultimet_steel_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/ultimet_steel_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:ultimet_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:ultimet_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_ultimet_ingot"
+    }
+}

--- a/kubejs/data/tfc/recipes/welding/vanadium_steel_double_ingot.json
+++ b/kubejs/data/tfc/recipes/welding/vanadium_steel_double_ingot.json
@@ -1,0 +1,13 @@
+{
+    "type": "tfc:welding",
+    "first_input": {
+      "item": "gtceu:tungsten_steel_ingot"
+    },
+    "second_input": {
+        "item": "gtceu:tungsten_steel_ingot"
+    },
+    "tier": 2,
+    "result": {
+      "item": "gregitas:double_tungsten_steel_ingot"
+    }
+}


### PR DESCRIPTION
Added tfc welding recipes for gregitas double ingots. This helps users who have found ingots like damascus steel in a temple use it to make things like mortar&pestles.