### PR TITLE
Quest Work

### DIFF
--- a/config/ftbquests/quests/chapters/create_brass_stage.snbt
+++ b/config/ftbquests/quests/chapters/create_brass_stage.snbt
@@ -176,11 +176,12 @@
 					id: "329CD5038624CE7D"
 					item: {
 						Count: 1
-						id: "create:sand_paper"
+						id: "itemfilters:tag"
 						tag: {
-							Damage: 0
+							value: "create:sandpaper"
 						}
 					}
+					title: "Any #create:sandpaper"
 					type: "item"
 				}
 			]
@@ -226,7 +227,10 @@
 		}
 		{
 			dependencies: ["07F2692B488525A9"]
-			description: ["{gravitas.quest.brass.desc.mechanical_crafter}"]
+			description: [
+				"{gravitas.quest.stage3.desc.mechcraft}"
+				"{gravitas.quest.brass.desc.mechanical_crafter}"
+			]
 			id: "1764A3635A95D162"
 			rewards: [{
 				count: 6
@@ -235,6 +239,7 @@
 				type: "item"
 			}]
 			tasks: [{
+				count: 15L
 				id: "12406A8C54F12327"
 				item: "create:mechanical_crafter"
 				type: "item"
@@ -252,6 +257,7 @@
 				item: "gtceu:diamond_ore"
 				type: "item"
 			}]
+			subtitle: "{gravitas.quest.stage3.subt.crushing}"
 			tasks: [{
 				count: 2L
 				id: "7F2CFE8877CA3F03"

--- a/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
@@ -28,6 +28,18 @@
 			x: -9.0d
 			y: 3.5d
 		}
+		{
+			id: "23B745C27A7164B5"
+			linked_quest: "1764A3635A95D162"
+			x: -4.5d
+			y: 0.0d
+		}
+		{
+			id: "70748678A4DFD422"
+			linked_quest: "7F8C6F7EA5F4CC8F"
+			x: -6.0d
+			y: 0.0d
+		}
 	]
 	quests: [
 		{
@@ -506,14 +518,15 @@
 					type: "item"
 				}
 				{
-					id: "2C78BC403E033364"
+					id: "647A2EA955572BC2"
 					item: {
 						Count: 1
-						id: "create:sand_paper"
+						id: "itemfilters:tag"
 						tag: {
-							Damage: 0
+							value: "create:sandpaper"
 						}
 					}
+					title: "Any #create:sandpaper"
 					type: "item"
 				}
 			]
@@ -551,35 +564,9 @@
 			y: 2.5d
 		}
 		{
-			dependencies: ["00F25F9C1F5B5DBB"]
-			description: ["{gravitas.quest.stage3.desc.mechcraft}"]
-			id: "46BE30EFB8425540"
-			tasks: [{
-				count: 15L
-				id: "0CCE93B76AEC025C"
-				item: { Count: 21, id: "create:mechanical_crafter" }
-				type: "item"
-			}]
-			x: -4.5d
-			y: 0.0d
-		}
-		{
-			dependencies: ["46BE30EFB8425540"]
-			id: "693B46904121EA55"
-			subtitle: "{gravitas.quest.stage3.subt.crushing}"
-			tasks: [{
-				count: 2L
-				id: "672EC68A84EA54F9"
-				item: { Count: 2, id: "create:crushing_wheel" }
-				type: "item"
-			}]
-			x: -6.0d
-			y: 0.0d
-		}
-		{
 			dependencies: [
-				"693B46904121EA55"
 				"554DA4CDDAC7CBB1"
+				"7F8C6F7EA5F4CC8F"
 			]
 			id: "7389402160789056"
 			subtitle: "{gravitas.quest.stage3.subt.rawrubber}"

--- a/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
@@ -907,6 +907,114 @@
 			x: 0.0d
 			y: -2.0d
 		}
+		{
+			dependencies: [
+				"735C1C31C684CC3E"
+				"5ACD19E705D43C48"
+			]
+			description: ["{gravitas.quest.steam.desc.steamminer}"]
+			icon: "gtceu:steam_miner"
+			id: "7ACD7DF43D0A5DD5"
+			optional: true
+			rewards: [{
+				id: "68ADA00E2834271E"
+				item: "gtceu:aluminium_crate"
+				type: "item"
+			}]
+			subtitle: "{gravitas.quest.steam.subt.steamminer}"
+			tasks: [{
+				id: "6C497EC5B4880DE8"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:steam_miner"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_miner"
+							}
+							{
+								Count: 1b
+								id: "gtceu:mv_miner"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_miner"
+							}
+						]
+					}
+				}
+				type: "item"
+			}]
+			title: "{gravitas.quest.steam.steamminer}"
+			x: 7.0d
+			y: -1.5d
+		}
+		{
+			dependencies: ["59BDE76B679AB4CC"]
+			description: ["{gravitas.quest.steam.desc.steammultiblocks}"]
+			id: "2D510A0E786AB46E"
+			optional: true
+			rewards: [{
+				count: 8
+				id: "116819DE043F1B35"
+				item: {
+					Count: 1
+					ForgeCaps: {
+						"tfc:item_heat": {
+							heat: 0.0f
+							ticks: 0L
+						}
+					}
+					id: "gtceu:bronze_ingot"
+				}
+				type: "item"
+			}]
+			tasks: [
+				{
+					id: "63E2276B323580AE"
+					item: {
+						Count: 1
+						id: "itemfilters:or"
+						tag: {
+							items: [
+								{
+									Count: 1b
+									id: "gtceu:steam_grinder"
+								}
+								{
+									Count: 1b
+									id: "gtceu:steam_oven"
+								}
+							]
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "31D80C62A94D0619"
+					item: "gtceu:steam_input_hatch"
+					type: "item"
+				}
+				{
+					id: "289155023AF3D43D"
+					item: "gtceu:steam_input_bus"
+					type: "item"
+				}
+				{
+					id: "4419099246C6CF0A"
+					item: "gtceu:steam_output_bus"
+					type: "item"
+				}
+			]
+			title: "{gravitas.quest.steam.steammultiblocks}"
+			x: 8.5d
+			y: -5.5d
+		}
 	]
 	title: "{gravitas.chapters.32.title}"
 }

--- a/config/ftbquests/quests/chapters/low_voltage.snbt
+++ b/config/ftbquests/quests/chapters/low_voltage.snbt
@@ -9,6 +9,7 @@
 	quest_links: [ ]
 	quests: [
 		{
+			dependencies: ["6A6D074B57ACB447"]
 			description: [
 				"{gravitas.quest.lv.desc.starter_1}"
 				""
@@ -200,10 +201,26 @@
 			description: ["{gravitas.quest.lv.desc.mixer}"]
 			id: "2BE4B6F1CCAA36AC"
 			tasks: [{
-				id: "18293B4BFE73030A"
-				item: "gtceu:lv_mixer"
+				id: "37A2314DE2DE95F3"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_kinetic_mixer"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_mixer"
+							}
+						]
+					}
+				}
 				type: "item"
 			}]
+			title: "{gravitas.quest.lv.title.mixer}"
 			x: 0.5d
 			y: 3.5d
 		}
@@ -774,6 +791,22 @@
 			}]
 			x: -1.0d
 			y: 0.0d
+		}
+		{
+			dependencies: [
+				"67DD027E0B0B3FE3"
+				"2A3517E5B9B0D69D"
+			]
+			description: ["{gravitas.quest.lv.desc.terminal}"]
+			id: "48B82C4DB40C2FFA"
+			tasks: [{
+				id: "61DF91112DA2465F"
+				item: "gtceu:terminal"
+				type: "item"
+			}]
+			title: "{gravitas.quest.lv.title.terminal}"
+			x: 0.5d
+			y: -0.5d
 		}
 	]
 	title: "{gravitas.chapters.16.title}"

--- a/kubejs/assets/gravitas/lang/en_us.json
+++ b/kubejs/assets/gravitas/lang/en_us.json
@@ -1059,6 +1059,8 @@
 	"gravitas.quest.steam.wrenches": "Wrenches",
 	"gravitas.quest.steam.wirec": "Wire Cutters",
 	"gravitas.quest.steam.firstcirc": "Our First Setup",
+	"gravitas.quest.steam.steamminer": "Miners",
+	"gravitas.quest.steam.steammultiblocks": "Steam Multiblocks",
 
 	"gravitas.quest.steam.desc.start": "Welcome to &b&lGregTech&r! To begin, we need 25 Bronze Ingots, not cheap. This is to be able to get our tools and machines!\\n\\nThe goal of this first part is going to get a setup for &bCrushed Raw Magnetite&r, needed to get Iron.",
 	"gravitas.quest.steam.desc.bronzep": "20 of those ingots are going to become plates, all necessary for crafting.",
@@ -1066,17 +1068,19 @@
 	"gravitas.quest.steam.desc.wrench": "You will probably be making a &6Bronze&r wrench, which needs 2 parts and a screw. Don't worry about &aPerfectly Forging&r any of the parts though, the tool will always turn out the same.",
 	"gravitas.quest.steam.desc.brass": "Brass is going to be needed for our first piston, this is made from &bZinc&r and &6Copper&r.",
 	"gravitas.quest.steam.desc.piston": "Hey, once we make this setup, we will get &aVanilla&r Iron, and use that recipe for pistons, much easier.",
-	"gravitas.quest.steam.desc.steamgen": "This machine uses &9Water&r and &0Coal&r to create steam. Steam is like the power source for all &6Steam Machines&r.",
+	"gravitas.quest.steam.desc.steamgen": "This machine uses &9Water&r and &0Coal&r to create steam. Steam is like the power source for all &6Steam Machines&r. \\n\\nYou can get all the &9Water&r that you may need by using water tanks from railcraft or if you want to keep your self on GregTech you can use the Primitive Pump",
 	"gravitas.quest.steam.desc.forgeh": "The forge hammer can crush ores into crushed ores, particularly useful for &bMagnetite&r. It can also compress ingots into plates.",
 	"gravitas.quest.steam.desc.pipes": "These pipes can transfer fluids, in our case, we want to transfer steam.",
 	"gravitas.quest.steam.desc.firstcirc": "To make the required &bCrushed Raw Magnetite&r, follow these steps:\\n\\n&l1.&r Place and fill the &eBoiler&r with water by clicking the middle bar with a filled water bucket. \\n\\n&l2. &rConnect a pipe from the boiler to the forge hammer using a &bWrench&r. \\n\\n&l3.&r Place coal in the boiler and raw magnetite in the forge hammer. \\n\\n&l&cMAKE SURE NOTHING IS BLOCKING THE VENT ON THE BACK OF THE FORGE HAMMER, NOT EVEN THE PIPE&r",
 	"gravitas.quest.steam.desc.alloysm": "Makes alloys.. needed for red alloy.",
-	"gravitas.quest.steam.desc.redstone": "Need redstone? Look for &cCinnabar&r, the &6TFC Guidebook&r will help as always.",
+	"gravitas.quest.steam.desc.redstone": "Need redstone? Look for &cCinnabar&r or &cCryolite&r, the &6TFC Guidebook&r will help as always.",
 	"gravitas.quest.steam.desc.wirec": "Wire cutters can turn plates into cables, and later be used for connecting and disconnecting cables.",
 	"gravitas.quest.steam.desc.rubber": "You can either use an alloy smelter, or TFC casting to get these. Either way, it's &eSulfur&r + &bRaw Rubber Pulp&r.",
 	"gravitas.quest.steam.desc.rubberplate": "Forge hammer into a heated basin",
 	"gravitas.quest.steam.desc.compress": "This can also be used to compress TFC ores into GregTech versions, which can be &6Bulk Blasted&r.",
 	"gravitas.quest.steam.desc.lv": "Well done, you've completed the Steam Age! The LV circuit is going to be used to get your first &bElectric&r machines, much faster and more powerful!\\n\\nOh and by the way, you will need dozens of these circuits, just so you know :)",
+	"gravitas.quest.steam.desc.steamminer": "This machines help you mine all ores in a certail radius the steam miner is a 9x9 around the miner as you progress on the voltage you will get better and bigger miners.",
+	"gravitas.quest.steam.desc.steammultiblocks": "These are the two multiblocks that are in the steam age they only use these hatch and buses\\n\\nThe Grinder is a great opcion for processing ores because it does 8 pararel recipes. \\nNote that it doesnt gives byproducts which is the same as all the macerators until HV\\n\\nThe Steam Oven works as a vanilla furnace and it does 8 recipes in pararel\\n\\nPD: GregTech hatchs and buses including the steam ones can auto import from inventories that are in the input or output face",
 
 	"gravitas.quest.steam.subt.start": "Who is this Greg guy?",
 	"gravitas.quest.steam.subt.screwdriver": "File + Hammer + Long Metal Rod",
@@ -1098,6 +1102,7 @@
 	"gravitas.quest.steam.subt.woodp": "Macerate Logs",
 	"gravitas.quest.steam.subt.coald": "Macerate Charcoal",
 	"gravitas.quest.steam.subt.compress": "To compress Wood Pulp",
+	"gravitas.quest.steam.subt.steamminer": "No more manual mining",
 
 
 	"gravitas.quest.lv.title.chem": "Chemical Reactor",
@@ -1114,6 +1119,8 @@
 	"gravitas.quest.lv.title.oxy_line": "Free Oxygen for Everyone!",
 	"gravitas.quest.lv.title.maint": "Machine Maintenance",
     "gravitas.quest.lv.title.aqueduct": "Unlimited Water",
+	"gravitas.quest.lv.title.mixer": "Basic Mixer",
+	"gravitas.quest.lv.title.terminal": "Multiblock Helper",
 
 	"gravitas.quest.lv.desc.starter_1": "Upgrading your machines with basic circuits will grant access to new recipes and increase their speed.",
 	"gravitas.quest.lv.desc.starter_2": "You can run any lower tier recipe on a higher tier machine. This is called Overclocking and can be configured in the machines GUI.",
@@ -1149,6 +1156,7 @@
 	"gravitas.quest.lv.desc.oxy_bucket": "This is sign TWO that you should probably make that passive oxygen line. There are many ways to obtain it, so i'll leave it to you and JEI.",
 	"gravitas.quest.lv.desc.ars_triox": "Put Cobaltite dust in with 3 buckets of oxygen to your EBF to get Arsenic Trioxide. You can process some of the byproducts for some of your O2 back.",
     "gravitas.quest.lv.desc.aqueduct": "Aqueducts provide an unlimited source of water. By placing a line of aqueducts starting next to a source block, the Aqueducts will transport the water until it reaches the end of the Aqueduct.\n\nAdditionally, interacting with the Aqueduct while holding a bucket will fill the bucket with the water inside of the Aqueduct. Aqueducts also support transporting liquids other than just water. Lava, and salt water can be transported as well.",
+	"gravitas.quest.lv.desc.terminal": "This item lets you autobuild any GregTech multiblock you just need to Shift and R-Click on the controller of the multiblock and you got your multiblock.\\nAll blocks that are missing will not be place any and hatchs or buses will be place somewhere in the multiblock is recommended to not have those blocks on the inventory and place them manually",
 
     "gravitas.quest.hv.title.any_hv_converter": "Any HV Energy Converter",
 


### PR DESCRIPTION
-Change the amount of the mechanical crafter quest to match the size needed to make crushing wheels
-Replaced quest on the chapter 3 related to the crushing wheels and mechanical crafter with links of the same quest on the create braze age chapther
-Change quest that needed create sand paper to tag filter create:sandpaper
-Change your first LV-Circuit quest to be dependant on 3x Basic Electronic Circuits
-Added mention for water tank and primitive pumps on the steam boiler quest
-Added mention of criolite on red alloy quest as another source of redstone
-Added quest for miner at steam age 
-Change the quest for the basic mixer to also alloy the basic kinetic mixer
-Added quest for steam multiblocks (grinder and oven)
-Added quest for the greg tech terminal