### PR TITLE
fix: use static json instead of querying at runtime

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -238,7 +238,13 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     "gtceu:polybenzimidazole_plate"
   ])
 
-  GTMaterialRegistry.registeredMaterials.forEach((id) => {
+  let refreshGTMaterials = false
+  if (refreshGTMaterials) {
+    JsonIO.write("kubejs/server_scripts/tags/gt_materials.json", {materials: GTMaterialRegistry.registeredMaterials.stream().map(mat => mat.toString()).toList()})
+  }
+
+  let registeredMaterials = JsonIO.read("kubejs/server_scripts/tags/gt_materials.json")
+  registeredMaterials.materials.forEach((id) => {
     event.add("tfc:saws", `${id}_saw`)
     event.add("tfc:hammers", `${id}_hammer`)
     event.add("tfc:knives", `${id}_knife`)


### PR DESCRIPTION
Set `refreshGTMaterials` to true to generate a new json when needed (you need NOW, as this will be your first run)