### PR TITLE
ULV Compressor recipe to turn 1 wool into 8 wool yarn

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -1474,6 +1474,15 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .duration(100)
     .EUt(LV)
 
+  //yarn
+
+  event.recipes.gtceu
+    .compressor("gregitas:wool_yarn_from_wool")
+    .itemInputs("1x tfc:wool")
+    .itemOutputs("8x tfc:wool_yarn")
+    .duration(100)
+    .EUt(ULV)
+
   //wool
 
   event.recipes.gtceu

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -1483,6 +1483,13 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .duration(100)
     .EUt(ULV)
 
+  event.recipes.gtceu
+    .compressor("gregitas:string_from_jute")
+    .itemInputs("1x tfc:jute_fiber")
+    .itemOutputs("2x minecraft:string")
+    .duration(100)
+    .EUt(ULV)
+
   //wool
 
   event.recipes.gtceu


### PR DESCRIPTION
Allows you to automate wool yarn production. Currently you have to manually craft and fire a spindle. And allows you to use jute to get string, allowing you to get wool stuff from plants instead of animals.