### PR TITLE
Allows Belt Grinder to cut TFC gems automatically

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -583,6 +583,22 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
         }
       }
     })
+    event.custom({
+      type: "vintageimprovements:polishing",
+      speedLimits: 1,
+      ingredients: [
+        {
+          item: `tfc:ore\/${gemStone}`
+        }
+      ],
+      results: [
+        {
+          item: `tfc:gem\/${gemStone}`,
+          count: 1
+        }
+      ],
+      processingTime: 40
+    })
   })
   event.shapeless("2x minecraft:blaze_powder", ["#forge:tools/mortars", "minecraft:blaze_rod"])
   event.shapeless("1x gtceu:saltpeter_dust", ["4x tfc:powder/saltpeter"])


### PR DESCRIPTION
Belt Grinder (from Vintage Improvements) can now process uncut TFC gems into their cut variants. This includes processing Kimberlite into diamonds.

Previously, Belt Grinder was only useful for making Rose Quartz into Polished Rose Quartz. I plan on adding more recipes to it, but that's going to happen in other PRs.