### PR TITLE
Makes Spring Coiling Machine produce Gregtech springs

### DIFF
--- a/kubejs/client_scripts/jei_hide/removals.js
+++ b/kubejs/client_scripts/jei_hide/removals.js
@@ -124,6 +124,10 @@ let hidePotions = (/** @type {Internal.HideJEIEventJS}*/ event) => {
     event.hide('gtceu:lv_extruder')
     event.hide('gtceu:wood_mallet')
 
+    // Vintage Improvements
+    event.hide('vintageimprovements:spring_coiling_machine_wheel')
+    event.hide(/^vintageimprovements:.*_spring/)
+
     // Thorium Reactors
     event.hide('thoriumreactors:generator_block')
     event.hide('thoriumreactors:fluid_evaporation_block')

--- a/kubejs/data/vintageimprovements/advancements/iron_spring.json
+++ b/kubejs/data/vintageimprovements/advancements/iron_spring.json
@@ -1,0 +1,37 @@
+{
+  "parent": "vintageimprovements:coiling",
+  "criteria": {
+    "0": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:springs/iron"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "display": {
+    "announce_to_chat": false,
+    "description": {
+      "color": "#DBA213",
+      "translate": "advancement.vintageimprovements.iron_spring.desc"
+    },
+    "frame": "task",
+    "hidden": false,
+    "icon": {
+      "item": "gtceu:iron_spring"
+    },
+    "show_toast": true,
+    "title": {
+      "translate": "advancement.vintageimprovements.iron_spring"
+    }
+  },
+  "requirements": [
+    [
+      "0"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -9,6 +9,7 @@ ServerEvents.recipes((event) => {
   tfcGregTools(event)
   gtceuAdd(event)
   createAdd(event)
+  coilingTweak(event)
   spaceDustChain(event)
   certusSemiconductors(event)
   gregifyAE2(event)

--- a/kubejs/server_scripts/mods/create/coilingTweak.js
+++ b/kubejs/server_scripts/mods/create/coilingTweak.js
@@ -1,0 +1,36 @@
+let coilingTweak = (/** @type {Internal.RecipesEventJS} */ event) => {
+
+    // Remove coiling machine wheel (snowflake item, only used in a single recipe)
+    // Replace iron with wrought iron to make the coiling machine more accessible early game, same as Create press
+    event.remove({ id: 'vintageimprovements:craft/spring_coiling_machine_wheel' })
+    event.replaceInput({ id: 'vintageimprovements:craft/spring_coiling_machine' }, 'vintageimprovements:spring_coiling_machine_wheel', '#forge:double_ingots/wrought_iron')
+    event.replaceInput({ id: 'vintageimprovements:craft/spring_coiling_machine' }, 'minecraft:iron_ingot', '#forge:ingots/wrought_iron')
+    
+    // Replace use of Vintage Improvements iron springs with a Forge tag (the tag points to a Gregtech iron spring)
+    event.replaceInput({ mod: 'vintageimprovements' }, 'vintageimprovements:iron_spring', '#forge:springs/iron')
+    
+    // Remove crafting of all Vintage Improvements springs
+    event.remove({ mod: 'vintageimprovements', id: /^vintageimprovements:coiling.*/})
+    
+    
+    // Add crafting of every Gregtech spring to Vintage Improvements spring coiling machine
+    event.forEachRecipe({ mod: 'gtceu', type: 'gtceu:bender', id: /^gtceu:bender\/bend_.*_rod_to(_small)?_spring/ }, (recipe) => {
+        // UGLY HACKS are used here to wrangle Gregtech recipes
+        let recipe_json = JSON.parse(recipe.json)
+
+        let input = recipe_json.inputs.item.filter((i) => i.content.type == "gtceu:sized")[0].content
+        let output = recipe_json.outputs.item.filter((i) => i.content.type == "gtceu:sized")[0].content
+           
+        event.custom({
+            type: 'vintageimprovements:coiling',
+            ingredients: [input.ingredient],
+            results: [{
+                    item: output.ingredient.item,
+                    count: output.count
+            }],
+            processingTime: recipe_json.duration / 2
+        })
+    
+    })
+
+}


### PR DESCRIPTION
Spring Coiling Machine from Vintage Improvements now makes Gregtech springs - making it usable in this modpack.

All Vintage Improvements springs are now uncraftable, and Vintage Improvements machines now use equivalent Gregtech springs.  Spring recipes are copied directly from Gregtech - thus, one long rod produces a single large spring, and one small rod produces two small springs.

The machine itself can now be crafted with just Wrought Iron ingots - same as Create press.