### PR TITLE
Makes Gregtech sulfur a valid fertilizer for Beneath crops

### DIFF
--- a/kubejs/data/beneath/beneath/nether_fertilizers/small_sulfur_dust.json
+++ b/kubejs/data/beneath/beneath/nether_fertilizers/small_sulfur_dust.json
@@ -1,0 +1,7 @@
+{
+  "ingredient": {
+    "item": "gtceu:small_sulfur_dust"
+  },
+  "flame": 0.025,
+  "decay": 0.05
+}

--- a/kubejs/data/beneath/beneath/nether_fertilizers/sulfur_dust.json
+++ b/kubejs/data/beneath/beneath/nether_fertilizers/sulfur_dust.json
@@ -1,0 +1,7 @@
+{
+  "ingredient": {
+    "item": "gtceu:sulfur_dust"
+  },
+  "flame": 0.1,
+  "decay": 0.2
+}


### PR DESCRIPTION
Beneath book says that sulfur is a valid Flame + Decay fertilizer, but the mod itself only applies those properties to TFC sulfur powder - which is fully replaced by Gregtech sulfur dust in this modpack.

This PR adds the same fertilizer properties to Gregtech sulfur dust, as well as small sulfur dust (at 1/4 the strength).