### PR TITLE
More misc tweaks :)

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschaptersnew2title.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschaptersnew2title.snbt
@@ -66,7 +66,7 @@
 			}]
 			title: "{gravitas.quest.stage2.start}"
 			x: -0.75d
-			y: 0.0d
+			y: 0.2d
 		}
 		{
 			dependencies: ["7DFCB6CF6B7824B1"]
@@ -235,8 +235,8 @@
 				title: "{gravitas.quest.stage2.zn}"
 				type: "item"
 			}]
-			x: 0.0d
-			y: -1.5d
+			x: -0.7000000000000002d
+			y: -2.0d
 		}
 		{
 			dependencies: ["5EE0CF563FDF196C"]
@@ -352,8 +352,8 @@
 				}
 				type: "item"
 			}]
-			x: 1.5d
-			y: -1.5d
+			x: 0.7999999999999999d
+			y: -2.0d
 		}
 		{
 			dependencies: ["3A6A2E6A9E75C645"]
@@ -365,8 +365,8 @@
 				item: { Count: 4, id: "gtceu:small_zinc_dust" }
 				type: "item"
 			}]
-			x: 3.0d
-			y: -1.5d
+			x: 2.3000000000000003d
+			y: -2.0d
 		}
 		{
 			dependencies: ["482EBEA7C1754B4C"]
@@ -386,8 +386,8 @@
 				}
 				type: "item"
 			}]
-			x: 4.5d
-			y: -1.5d
+			x: 3.8000000000000003d
+			y: -2.0d
 		}
 		{
 			dependencies: ["5A094944E06D050A"]
@@ -407,8 +407,8 @@
 				}
 				type: "item"
 			}]
-			x: 6.5d
-			y: -1.5d
+			x: 5.799999999999999d
+			y: -2.0d
 		}
 		{
 			dependencies: ["44F8C37DD9151C22"]
@@ -426,7 +426,7 @@
 				title: "{gravitas.quest.stage2.chisel}"
 				type: "item"
 			}]
-			x: 4.0d
+			x: 1.5d
 			y: 0.5d
 		}
 		{
@@ -525,7 +525,7 @@
 				type: "item"
 			}]
 			x: 7.5d
-			y: -2.5d
+			y: -2.7d
 		}
 		{
 			dependencies: [
@@ -539,8 +539,8 @@
 				item: "create:millstone"
 				type: "item"
 			}]
-			x: 6.5d
-			y: -0.5d
+			x: 3.0d
+			y: -1.0d
 		}
 		{
 			dependencies: ["139A1628E970A1F1"]
@@ -566,12 +566,13 @@
 					type: "item"
 				}
 			]
-			x: 5.0d
-			y: -0.5d
+			x: 1.5d
+			y: -1.0d
 		}
 		{
 			dependencies: ["44F8C37DD9151C22"]
 			id: "2FB772C17B0067E8"
+			optional: true
 			shape: "gear"
 			tasks: [{
 				id: "7D8466FA49B457A0"
@@ -594,8 +595,8 @@
 				title: "{gravitas.quest.stage2.graphite}"
 				type: "item"
 			}]
-			x: 5.0d
-			y: 1.0d
+			x: 3.0d
+			y: 0.4d
 		}
 		{
 			dependencies: ["44F8C37DD9151C22"]
@@ -617,14 +618,16 @@
 				}
 				type: "item"
 			}]
-			x: 4.0d
-			y: 2.0d
+			x: 4.9d
+			y: 3.5d
 		}
 		{
 			dependencies: [
-				"2FB772C17B0067E8"
-				"000CF8AEF83DEC40"
+				"18EEA197750E7C38"
+				"2B1060BB6F2CD77B"
 			]
+			dependency_requirement: "one_completed"
+			description: ["{gravitas.quest.stage2.desc.graphite}"]
 			id: "10CC2F9265A66C65"
 			subtitle: "{gravitas.quest.stage2.desc.graph}"
 			tasks: [{
@@ -632,8 +635,8 @@
 				item: "tfc:powder/graphite"
 				type: "item"
 			}]
-			x: 6.5d
-			y: 0.5d
+			x: 6.0d
+			y: -0.5d
 		}
 		{
 			dependencies: ["63626742A6CAE4B7"]
@@ -644,7 +647,7 @@
 				item: "tfc:powder/kaolinite"
 				type: "item"
 			}]
-			x: 6.5d
+			x: 7.0d
 			y: 2.0d
 		}
 		{
@@ -661,8 +664,8 @@
 				item: "tfc:fire_clay"
 				type: "item"
 			}]
-			x: 7.5d
-			y: 0.0d
+			x: 7.000000000000002d
+			y: -0.5000000000000001d
 		}
 		{
 			dependencies: ["510708C4BDFBB6EF"]
@@ -895,8 +898,8 @@
 				}
 				type: "item"
 			}]
-			x: 8.0d
-			y: 1.0d
+			x: 7.600000000000001d
+			y: 0.5000000000000001d
 		}
 		{
 			dependencies: ["514BA24579AE363B"]
@@ -933,7 +936,7 @@
 				}
 				type: "item"
 			}]
-			x: 8.5d
+			x: 8.6d
 			y: 2.5d
 		}
 		{
@@ -1110,7 +1113,7 @@
 				item: "createaddition:rolling_mill"
 				type: "item"
 			}]
-			x: 8.5d
+			x: 8.3d
 			y: -2.0d
 		}
 		{
@@ -1132,7 +1135,7 @@
 				}
 				type: "item"
 			}]
-			x: 8.5d
+			x: 8.7d
 			y: -0.5d
 		}
 		{
@@ -1145,8 +1148,8 @@
 				item: "gtceu:firebricks"
 				type: "item"
 			}]
-			x: 9.5d
-			y: -1.0d
+			x: 9.799999999999999d
+			y: -1.3000000000000003d
 		}
 		{
 			dependencies: [
@@ -1170,8 +1173,8 @@
 				}
 				type: "item"
 			}]
-			x: 10.5d
-			y: 0.5d
+			x: 10.3d
+			y: 0.30000000000000004d
 		}
 		{
 			dependencies: ["48F40B8850D384F9"]
@@ -1319,8 +1322,8 @@
 				title: "{gravitas.quest.stage2.gemd}"
 				type: "item"
 			}]
-			x: 3.5d
-			y: -0.5d
+			x: 0.0d
+			y: -1.0d
 		}
 		{
 			dependencies: ["48F40B8850D384F9"]
@@ -1440,6 +1443,91 @@
 			}]
 			x: 7.0d
 			y: -3.75d
+		}
+		{
+			dependencies: [
+				"000CF8AEF83DEC40"
+				"2FB772C17B0067E8"
+			]
+			description: ["{gravitas.quest.stage2.desc.graphite_ore_path}"]
+			id: "18EEA197750E7C38"
+			optional: true
+			tasks: [{
+				id: "7BF668D0A9780CB0"
+				title: "{uwu}"
+				type: "checkmark"
+			}]
+			title: "{gravitas.quest.stage2.graphite_ore_path}"
+			x: 4.300000000000001d
+			y: -0.5d
+		}
+		{
+			dependencies: [
+				"7F8C6F7EA5F4CC8F"
+				"66B9834887F40FD2"
+				"0EF7B8AB3859A822"
+			]
+			description: ["{gravitas.quest.stage2.desc.graphite_coke_path}"]
+			id: "2B1060BB6F2CD77B"
+			optional: true
+			tasks: [{
+				id: "0D600D88A93EAF0F"
+				type: "checkmark"
+			}]
+			title: "{gravitas.quest.stage2.graphite_coke_path}"
+			x: 6.0d
+			y: 0.8d
+		}
+		{
+			dependencies: [
+				"679D7B1E110BE18E"
+				"59BCE9D352413724"
+			]
+			id: "66B9834887F40FD2"
+			optional: true
+			tasks: [{
+				id: "777224FB95D09716"
+				item: "gtceu:coke_gem"
+				type: "item"
+			}]
+			x: 6.0d
+			y: 2.0d
+		}
+		{
+			dependencies: ["23B745C27A7164B5"]
+			description: [""]
+			id: "0EF7B8AB3859A822"
+			optional: true
+			subtitle: "{gravitas.quest.stage3.subt.crushing}"
+			tasks: [{
+				count: 2L
+				id: "0DA79D4CC3098D13"
+				item: "create:crushing_wheel"
+				type: "item"
+			}]
+			title: "{gravitas.quest.brass.crushing_wheel}"
+			x: 4.5d
+			y: 0.8d
+		}
+		{
+			hide_dependency_lines: false
+			id: "59BCE9D352413724"
+			optional: true
+			tasks: [
+				{
+					count: 25L
+					id: "4B1DB4789879381C"
+					item: "gtceu:coke_oven_bricks"
+					type: "item"
+				}
+				{
+					id: "0EAA64D027DD5AAD"
+					item: "gtceu:coke_oven"
+					type: "item"
+				}
+			]
+			x: 4.5d
+			y: 2.0d
 		}
 	]
 	title: "{gravitas.chapters.2.title}"

--- a/config/ftbquests/quests/chapters/medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/medium_voltage.snbt
@@ -711,6 +711,7 @@
 			dependencies: ["262AE37765B139BE"]
 			description: ["Also makes those magnetic iron rods for just some energy - save your redstone!"]
 			id: "1BD5B25B80EC0F97"
+			optional: true
 			rewards: [{
 				count: 2
 				id: "46C552EDE88FDAF3"
@@ -781,24 +782,6 @@
 			title: "{gravitas.quest.mv.title.extruder_molds}"
 			x: 0.0d
 			y: -3.0d
-		}
-		{
-			dependencies: ["1BD5B25B80EC0F97"]
-			description: ["You'll need these for MV Electric Motors, a component for many MV machines"]
-			id: "497028C92F886AE0"
-			rewards: [{
-				id: "7A94DDAC0325A87A"
-				item: "gtceu:magnetic_steel_rod"
-				random_bonus: 2
-				type: "item"
-			}]
-			tasks: [{
-				id: "638FE467700933F2"
-				item: "gtceu:magnetic_steel_rod"
-				type: "item"
-			}]
-			x: 0.0d
-			y: 3.0d
 		}
 		{
 			dependencies: ["72DACA35906D7E5B"]
@@ -1131,7 +1114,7 @@
 			y: -1.5d
 		}
 		{
-			dependencies: ["262AE37765B139BE"]
+			dependencies: ["6A82827978D3483B"]
 			description: ["{gravitas.quest.mv.desc.greenhouse}"]
 			id: "17B205E2864BF572"
 			optional: true
@@ -1140,8 +1123,8 @@
 				item: "gtceu:greenhouse"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 9.0d
+			x: 3.0d
+			y: 4.5d
 		}
 	]
 	title: "{gravitas.chapters.17.title}"

--- a/kubejs/assets/gravitas/lang/en_us.json
+++ b/kubejs/assets/gravitas/lang/en_us.json
@@ -146,6 +146,8 @@
     "gravitas.quest.stage2.gemd": "Gem Dusts",
 	"gravitas.quest.stage2.files": "Files",
     "gravitas.quest.stage2.greg": "GregTech - Steam Age",
+	"gravitas.quest.stage2.graphite_ore_path": "Option 1: Graphite Ore",
+	"gravitas.quest.stage2.graphite_coke_path": "Option 2: Coke",
 
     "gravitas.quest.stage2.desc.start": "Tin is going to be the first ore we want to find, since it allows us to create &6Bronze&r, needed for the next tier Anvil and &4&lGregTech&r.\\n\\nCassiterite is the most common tin ore, now would be a good time to tell you to &c&lCHECK JEI&r on greg ores, since they have vein info.",
     "gravitas.quest.stage2.desc.zn": "Zinc, most commonly found in &bSphalerite&r, is needed to get started with create. This one's a little harder to find, but as always, check the &6TFC Guidebook&r.",
@@ -153,7 +155,7 @@
     "gravitas.quest.stage2.desc.file": "At the end of this questline you need Steel Screws. Don't &oscrew&r yourself over by not making this, and later having to come back and make more Bronze.",
     "gravitas.quest.stage2.desc.kaolin": "This clay is a nightmare to get, sometimes taking over &c10K Blocks&r of travel.\\n\\nIt is located &lVERY&r far southeast, in rainforests. Check the temp and rainfall stats in your inventory as you explore, you need at least 18C avg temps and 300mm yearly rainfall.\\n\\nPlease tell me you brought a Waystone...",
     "gravitas.quest.stage2.desc.kaolinp": "Smelt kaolin clay down in your charcoal forge for 20%% of it to become powder. Use &6Create Bulk Blasting&r for 100%% conversion.",
-    "gravitas.quest.stage2.desc.graph": "Throw Graphite into the Millstone",
+    "gravitas.quest.stage2.desc.graph": "You have 2 options...",
     "gravitas.quest.stage2.desc.igneousd": "Crush some Igneous Extrusive rocks, like &bBasalt&r, to get Igneous dust. Combine with small zinc dust for igneous alloy dust!",
     "gravitas.quest.stage2.desc.wroughtp": "20 is how many you need for the Blast Furnace, you'll need more for other stuff like the Encased Fan.",
     "gravitas.quest.stage2.desc.bloomery": "I'm guessing you have encountered &osome&r form of iron while mining, whether it be &blimonite&r, &bmagnetite&r, &bhematite&r, or some other form of it. Those smelt down into cast iron, but we want the much stronger &cWrought Iron&r, for this we need to build the bloomery, check the details in the &6TFC Guidebook&r.",
@@ -168,6 +170,9 @@
     "gravitas.quest.stage2.desc.fireClay": "A much stronger Clay that is used for Crucibles, unbreakable molds, and multiblocks",
     "gravitas.quest.stage2.desc.wrought_nugget": "Wrought iron just got a lot less tedious! &bJust smelt purified iron nuggets.&r \\n\\nYou'll need a GregTech compressor or alloy smelter to make them into ingots.",
     "gravitas.quest.stage2.desc.iron_nugget": "Craft these using a saw. \\n\\nSmelt them and see what happens...",
+    "gravitas.quest.stage2.desc.graphite": "Finding graphite ore in the world can be a pain to find since it spawns so low. You have two options to get graphite. If you haven't already found it, consider making a coke oven rather than searching for the ore.",
+    "gravitas.quest.stage2.desc.graphite_ore_path": "The first way of getting graphite is simple. Just mill or crush graphite ore! This relies on you FINDING Graphite Ore first, which can be very time-consuming.",
+    "gravitas.quest.stage2.desc.graphite_coke_path": "If you can't find graphite ore, you can use a coke oven instead! This can take a while, but it might be easier than hoping you find some graphite ore.",
 
     "gravitas.quest.stage2.subt.doublebronze": "Same deal as Copper Anvil",
     "gravitas.quest.stage2.subt.file": "You'll regret ignoring this",

--- a/kubejs/assets/gravitas/lang/en_us.json
+++ b/kubejs/assets/gravitas/lang/en_us.json
@@ -1178,7 +1178,7 @@
     "gravitas.quest.mv.title.raw_oil": "Oil",
     "gravitas.quest.mv.title.extruder_molds": "Extruder Molds",
     "gravitas.quest.mv.title.brewery": "Brewery",
-    "gravitas.quest.mv.title.pre_ethylene": "Now you can Make",
+    "gravitas.quest.mv.title.pre_ethylene": "Ethylene Time!",
     "gravitas.quest.mv.title.integrated_circuits": "Advanced Integrated Circuit",
     "gravitas.quest.mv.title.gems": "Ruby and Emerald",
 
@@ -1191,7 +1191,7 @@
     "gravitas.quest.mv.subtitle.sulfur_acid": "Just add water!",
     "gravitas.quest.mv.subtitle.brewery": "Not that kind of brewery",
     "gravitas.quest.mv.subtitle.ethanol": "Not for drinking",
-    "gravitas.quest.mv.subtitle.pre_ethylene": "Are you ready for getting ethylene",
+    "gravitas.quest.mv.subtitle.pre_ethylene": "Me when it's ethylene time",
     "gravitas.quest.mv.subtitle.polyethylene": "Even more oxygen",
     "gravitas.quest.mv.subtitle.advance_assembler": "Greggers, ASSEMBLE!",
     "gravitas.quest.mv.subtitle.integrated_circuits": "A new era",

--- a/kubejs/client_scripts/jei_add.js
+++ b/kubejs/client_scripts/jei_add.js
@@ -3,6 +3,10 @@
 const addItems = (/** @type {Internal.AddJEIEventJS}*/ event) => {
     event.add("framedblocks:framed_double_slab")
     event.add("framedblocks:framed_double_panel")
+
+    // Only AllTheTweaks items to stay, all others were hidden
+    event.add("allthetweaks:nether_star_block")
+    event.add("allthetweaks:ender_pearl_block")
 }
 
 const addItemTooltips = (/** @type {Internal.ItemTooltipEventJS} */ event) => {

--- a/kubejs/client_scripts/jei_add.js
+++ b/kubejs/client_scripts/jei_add.js
@@ -1,0 +1,11 @@
+// priority 10
+
+const addItems = (/** @type {Internal.AddJEIEventJS}*/ event) => {
+    event.add("framedblocks:framed_double_slab")
+    event.add("framedblocks:framed_double_panel")
+}
+
+const addItemTooltips = (/** @type {Internal.ItemTooltipEventJS} */ event) => {
+    event.add("framedblocks:framed_double_slab", Text.gray("Needed for use with the Schematicannon. Otherwise, just combine slabs in-world."))
+    event.add("framedblocks:framed_double_panel", Text.gray("Needed for use with the Schematicannon. Otherwise, just combine panels in-world."))
+}

--- a/kubejs/client_scripts/jei_hide/removals.js
+++ b/kubejs/client_scripts/jei_hide/removals.js
@@ -164,4 +164,18 @@ let hideItems = (/** @type {Internal.HideJEIEventJS}*/ event) => {
 
     // Jumbo Furnace
     event.hide('jumbofurnace:jumbo_furnace')
+
+    // AllTheTweaks
+    // Later unhide ender pearl + nether star block
+    event.hide(`/^allthetweaks:.*/`)
+
+    // Global remove + hides
+    global.itemsToRemove.forEach(item => event.hide(item))
+    global.fluidsWithBucketsToRemove.forEach(item => event.hide(item + "_bucket"))
+}
+
+
+let hideFluids = (/** @type {Internal.HideJEIEventJS}*/ event) => {
+  global.fluidsToRemove.forEach(item => event.hide(item))
+  global.fluidsWithBucketsToRemove.forEach(item => event.hide(item))
 }

--- a/kubejs/client_scripts/jei_hide/removals.js
+++ b/kubejs/client_scripts/jei_hide/removals.js
@@ -75,6 +75,10 @@ let hideItems = (/** @type {Internal.HideJEIEventJS}*/ event) => {
     event.hide("immersiveengineering:coke")
     event.hide(`/^immersiveengineering:.*hemp_seed.*/`)
 
+    //ID
+    event.hide("integrateddynamics:squeezer")
+    event.hide("integrateddynamics:mechanical_squeezer")
+
     //ATM
     event.hide("allthemodium:teleport_pad")
 

--- a/kubejs/client_scripts/jei_hide/removals.js
+++ b/kubejs/client_scripts/jei_hide/removals.js
@@ -23,7 +23,7 @@ const toolsToRemove = [
 
 ]
 
-let hidePotions = (/** @type {Internal.HideJEIEventJS}*/ event) => {
+let hideItems = (/** @type {Internal.HideJEIEventJS}*/ event) => {
   oresToRemove.forEach((ore) => {
     event.hide(`potionsmaster:${ore}_powder`)
     event.hide(`potionsmaster:calcinated${ore}_powder`)

--- a/kubejs/client_scripts/main_client.js
+++ b/kubejs/client_scripts/main_client.js
@@ -8,12 +8,17 @@ NetworkEvents.dataReceived('customTask', event => {
 })
 
 JEIEvents.hideItems(event => {
-  hidePotions(event)
+  hideItems(event)
 })
 
 JEIEvents.removeCategories(event => {
   hideCats(event)
 })
+
+JEIEvents.addItems(event => {
+  addItems(event)
+})
+
 ClientEvents.lang("en_us", (event) => {
   addGregOresLang(event)
   addGregitasName(event)
@@ -25,4 +30,5 @@ ItemEvents.tooltip(event => {
   addModNameTooltipToCreativeTab(event)
   circuitTooltips(event)
   addMetalRatioToVessels(event)
+  addItemTooltips(event)
 })

--- a/kubejs/client_scripts/main_client.js
+++ b/kubejs/client_scripts/main_client.js
@@ -11,6 +11,10 @@ JEIEvents.hideItems(event => {
   hideItems(event)
 })
 
+JEIEvents.hideFluids(event => {
+  hideFluids(event)
+})
+
 JEIEvents.removeCategories(event => {
   hideCats(event)
 })

--- a/kubejs/server_scripts/mods/create/createAdd.js
+++ b/kubejs/server_scripts/mods/create/createAdd.js
@@ -371,6 +371,25 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
             type: 'create:mixing',
             ingredients: [
                 {
+                    fluid: 'tfc:salt_water',
+                    nbt: {},
+                    amount: 1000
+                },
+            ],
+            results: [
+                {
+                    item: 'gtceu:salt_dust',
+                    count: 1
+                }
+            ],
+            heatRequirement: "heated"
+        }
+    )
+    event.custom(
+        {
+            type: 'create:mixing',
+            ingredients: [
+                {
                     fluid: 'minecraft:water',
                     nbt: {},
                     amount: 1000

--- a/kubejs/server_scripts/mods/create/createAdd.js
+++ b/kubejs/server_scripts/mods/create/createAdd.js
@@ -385,6 +385,7 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
             heatRequirement: "heated"
         }
     )
+
     event.custom(
         {
             type: 'create:mixing',
@@ -644,8 +645,11 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     addMoldChiselDeploying("create:andesite_alloy", "tfc:ceramic/ingot_mold", 0.1, "gregitas_core:igneous_alloy", 144)
     tfcSaplings.forEach(wood => {
         event.recipes.create.cutting([`12x tfc:wood/lumber/${wood}`, Item.of('gtceu:wood_dust').withChance(0.1)], `tfc:wood/log/${wood}`, 150)
-        event.recipes.create.cutting([`tfc:wood/stripped_log/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/log/${wood}`)
-        event.recipes.create.cutting([`12x tfc:wood/lumber/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/stripped_log/${wood}`, 150)
+        event.recipes.create.cutting([`tfc:wood/stripped_log/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/log/${wood}`, 50)
+        event.recipes.create.cutting([`tfc:wood/stripped_wood/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/wood/${wood}`, 50)
+        event.recipes.create.cutting(`4x tfc:wood/support/${wood}`, `tfc:wood/stripped_log/${wood}`, 150)
+        event.recipes.create.cutting([`12x tfc:wood/lumber/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/wood/${wood}`, 150)
+        event.recipes.create.cutting([`12x tfc:wood/lumber/${wood}`, Item.of('gtceu:wood_dust').withChance(0.05)], `tfc:wood/stripped_wood/${wood}`, 150)
     })
     event.recipes.create.cutting(["2x immersiveengineering:slab_treated_wood_horizontal"], "gtceu:treated_wood_planks", 150)
 

--- a/kubejs/server_scripts/mods/create/createAdd.js
+++ b/kubejs/server_scripts/mods/create/createAdd.js
@@ -659,6 +659,13 @@ let createAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     event.recipes.create.compacting('minecraft:paper', ['#forge:dusts/wood', Fluid.of('gtceu:distilled_water', 100)])
     event.recipes.create.compacting('minecraft:paper', ['#forge:dusts/paper', Fluid.of('gtceu:distilled_water', 100)])
 
+    // Fire clay knapping automation
+    // Player will need to use recipe filter
+    event.recipes.create.compacting('tfc:ceramic/unfired_crucible', '5x tfc:fire_clay')
+    event.recipes.create.compacting('tfcchannelcasting:unfired_mold_table', '5x tfc:fire_clay')
+    event.recipes.create.compacting('4x tfcchannelcasting:unfired_channel', '5x tfc:fire_clay')
+    event.recipes.create.compacting('2x tfc:ceramic/unfired_fire_ingot_mold', '5x tfc:fire_clay')
+
     // TFC metallurgy
     event.recipes.create.sequenced_assembly('tfc:metal/ingot/high_carbon_steel', 'tfc:metal/ingot/pig_iron', 
         event.recipes.create.pressing('tfc:metal/ingot/pig_iron', 'tfc:metal/ingot/pig_iron')

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -1532,7 +1532,7 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .duration(60)
     .EUt(LV)
 
-  //wrought iron anvil
+  // anvils
 
   event.recipes.gtceu
     .fluid_solidifier("gregitas:wrought_iron_anvil")
@@ -1541,6 +1541,14 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .itemOutputs("tfc:metal/anvil/wrought_iron")
     .duration(400)
     .EUt(LV)
+
+  event.recipes.gtceu
+    .fluid_solidifier("gregitas:steel_anvil")
+    .notConsumable("gtceu:anvil_casting_mold")
+    .inputFluids(Fluid.of("gtceu:steel", 2016))
+    .itemOutputs("railcraft:steel_anvil")
+    .duration(400)
+    .EUt(MV)
 
   //amethyst conversion (cut amethyst only has 1 source as of adding, from tfc ore)
 

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -584,7 +584,7 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .damageIngredient(["#forge:tools"])
   event.recipes.kubejs
     .shaped("3x gtceu:compressed_coke_clay", ["CCC", "SFS", "SSS"], {
-      C: "tfc:fire_clay",
+      C: "minecraft:clay_ball",
       S: "#forge:sand",
       F: "gtceu:brick_wooden_form"
     })

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -603,6 +603,17 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
   })
   event.shapeless("2x minecraft:blaze_powder", ["#forge:tools/mortars", "minecraft:blaze_rod"])
   event.shapeless("1x gtceu:saltpeter_dust", ["4x tfc:powder/saltpeter"])
+  event.shaped(
+    'tfc:powder/saltpeter',
+    [
+      '  S',
+      '   ',
+      '   ',
+    ],
+    {
+      S: 'gtceu:saltpeter_dust'
+    }
+  )
   event.recipes.create.pressing(
     [{ item: "tfc:refined_iron_bloom" }],
     [

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -1080,19 +1080,25 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     C: "minecraft:fire_charge",
     F: "tfc:crucible"
   })
+  //Railcraft End
 
   shaped("framedblocks:framed_chest", ["FRF", "RCR", "FRF"], {
     F: "framedblocks:framed_cube",
     R: "#forge:rods/cast_iron",
     C: "#forge:chests/wooden"
   })
-
   shaped("framedblocks:framed_secret_storage", ["RFR", "FCF", "RFR"], {
     F: "framedblocks:framed_cube",
     R: "#forge:rods/cast_iron",
     C: "framedblocks:framed_chest"
   })
-  //Railcraft End
+  // Blocks needed for schematicannon
+  shaped("framedblocks:framed_double_slab", ["S", "S"], {
+    S: "framedblocks:framed_slab"
+  })
+  shaped("framedblocks:framed_double_panel", ["PP"], {
+    P: "framedblocks:framed_panel"
+  })
 
   //ThoriumReactors Start
   event.recipes.gtceu

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -614,30 +614,6 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       S: 'gtceu:saltpeter_dust'
     }
   )
-  event.recipes.create.pressing(
-    [{ item: "tfc:refined_iron_bloom" }],
-    [
-      {
-        type: "tfc:heatable",
-        min_temp: 921,
-        ingredient: {
-          item: "tfc:raw_iron_bloom"
-        }
-      }
-    ]
-  )
-  event.recipes.create.pressing(
-    [{ item: "gtceu:wrought_iron_ingot" }],
-    [
-      {
-        type: "tfc:heatable",
-        min_temp: 921,
-        ingredient: {
-          item: "tfc:refined_iron_bloom"
-        }
-      }
-    ]
-  )
   event.custom({
     type: "create:deploying",
     ingredients: [

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -21,6 +21,11 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   // After adding mods, use this to update client_scripts/recipe_categories:
   // logRecipeCategories();
 
+  // Global remove + hides
+  global.itemsToRemove.forEach(item => event.remove({output: item}))
+  // Create bucket filling
+  global.fluidsWithBucketsToRemove.forEach(item => event.remove({input: item}))
+
   event.remove({ id: "tfc:crafting/bloomery" })
   event.remove({ id: "computercraft:computer_normal" })
   event.remove({ id: "computercraft:computer_advanced_upgrade" })
@@ -31,6 +36,8 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "computercraft:wireless_modem_normal" })
   event.remove({ id: "computercraft:wireless_modem_advanced"})
   event.remove({ id: "vintageimprovements:curving/iron_sheet"})
+  event.remove({ id: "vintageimprovements:rolling/andesite_plate"})
+  event.remove({ id: "vintageimprovements:pressing/andesite_alloy"})
   //GT
   event.remove({ id: "gtceu:shaped/stick_wrought_iron" })
   event.remove({ id: "gtceu:cutter/cut_glass_block_to_plate_water"})
@@ -315,6 +322,8 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "immersiveengineering:crafting/craftingtable"})
   event.remove({ id: "immersiveengineering:crafting/workbench"})
   event.remove({ id: "immersiveengineering:crafting/ersatz_leather"})
+  event.remove({ id: "createaddition:pressing/constantan_ingot"})
+  event.remove({output: `/^immersiveengineering:plate_.*/`, input: "immersiveengineering:wirecutter"})
   
 
   //Firmalife

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -249,6 +249,7 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ mod: "railcraft", id: `/^railcraft:.*coke.*/`})
   event.remove({ mod: "railcraft", id: `/^railcraft:crusher\/.*cobbleston.*/`})
   event.remove({ id: "railcraft:invar_ingot_crafted_with_ingots"})
+  event.remove({ id: "railcraft:steel_anvil"})
   //Woodencog
   event.remove({ id: /^woodencog:cutting\/.*_rod/, mod: "woodencog" })
   event.remove({ id: /^woodencog:cutting\/.*_alloy/, mod: "woodencog" })

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -121,6 +121,7 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.forEachRecipe({id: "woodencog:crafting/kinetics/fluid_tank"}, r => {
     event.recipes.kubejs.shaped("create:fluid_tank", r.json.asMap().pattern, r.json.asMap().key).replaceIngredient("#tfc:barrels", Item.empty).id(r.getId())
   })
+  event.replaceInput({id: "create_connected:crafting/kinetics/fluid_vessel"}, "minecraft:barrel", "#tfc:barrels")
   event.forEachRecipe({id: "woodencog:crafting/sequenced_assembly/track"}, r => {
     let modifiedResult = unwrapValue(r.get("results"))[0].get("item")
     modifiedResult = Item.of(modifiedResult, 6)

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -130,6 +130,9 @@ let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   })
 event.replaceInput({id: "woodencog:crushing/milling_raw_quartzite" }, "tfc:rock/cobble/quartzite", "tfc:rock/raw/quartzite")
 
+  event.replaceOutput([{id: "woodencog:crushing/crushing_saltpeter"}, {id: "woodencog:crushing/milling_saltpeter"}], "gtceu:saltpeter_dust", "tfc:powder/saltpeter")
+  event.remove("tfc:quern/saltpeter")
+
   //Functional Storage
   event.replaceInput(
     { id: "functionalstorage:framed_storage_controller" },

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -78,6 +78,7 @@ const tfcShipTypes = [
 ]
 let replaceRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.replaceOutput({ type: "minecraft:crafting_shaped" }, "minecraft:torch", "tfc:torch")
+  event.replaceInput({ id: "minecraft:writable_book" }, "minecraft:ink_sac", "minecraft:black_dye")
 
   event.replaceInput({ type: "minecraft:crafting_shaped" }, "minecraft:torch", "tfc:torch")
   event.replaceInput({ type: "minecraft:crafting_shaped" }, "minecraft:anvil", "tfc:metal/anvil/wrought_iron")
@@ -211,6 +212,7 @@ event.replaceInput({id: "woodencog:crushing/milling_raw_quartzite" }, "tfc:rock/
   event.replaceInput({ id: "iceandfire:dragon_meal"}, "#iceandfire:dragon_food_meat", "#tfc:foods/meats")
   event.replaceInput({ id: "woodencog:crafting/schematics/schematicannon"}, "minecraft:smooth_stone", "#tfc:rock/smooth")
   event.replaceInput({ id: "create:haunting/poisonous_potato"}, "minecraft:potato", "tfc:food/potato")
+  event.replaceInput({ id: "create:haunting/glow_ink_sac" }, "minecraft:ink_sac", "minecraft:black_dye")
   event.replaceOutput({ id: `/^gtceu:smelting\/smelt_.*_ore_to_ingot/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")
   event.replaceOutput({ id: `/^gtceu:blasting\/smelt_.*_ore_to_ingot/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")
   event.replaceOutput({ id: `/^minecraft:iron_ingot_from_.*/`}, "minecraft:iron_ingot", "tfc:metal/ingot/cast_iron")

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -248,6 +248,37 @@ event.replaceInput({id: "woodencog:crushing/milling_raw_quartzite" }, "tfc:rock/
   event.replaceInput({ mod: "createdeco"}, "create:ochrum", "tfc:rock/raw/claystone")
   event.replaceInput({ mod: "createdeco"}, "create:brass_block", "#forge:storage_blocks/brass")
   event.replaceInput({ mod: "createdeco"}, "create:zinc_block", "#forge:storage_blocks/zinc")
+
+  event
+    .custom({
+      type: "create:compacting",
+      ingredients: [
+        {
+          item: "tfc:raw_iron_bloom"
+        },
+      ],
+      results: [
+        {
+          item: "tfc:refined_iron_bloom"
+        }
+      ],
+      heatRequirement: "superheated"
+    })
+  event
+    .custom({
+      type: "create:compacting",
+      ingredients: [
+        {
+          item: "tfc:refined_iron_bloom"
+        },
+      ],
+      results: [
+        {
+          item: "gtceu:wrought_iron_ingot"
+        }
+      ],
+      heatRequirement: "superheated"
+    })
   
 //honey
 

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -168,6 +168,11 @@ const ice = ["blue", "white", "sapphire", "silver"]
 const lightning = ["electric", "amethyst", "copper", "black"]
 
 const addItemTags = (/** @type {TagEvent.Item} */ event) => {
+  // Global remove + hides
+  global.itemsToRemove.forEach(item => event.removeAllTagsFrom(item))
+  global.fluidsToRemove.forEach(item => event.removeAllTagsFrom(item))
+  global.fluidsWithBucketsToRemove.forEach(item => event.removeAllTagsFrom(item))
+
   fire.forEach((color) => {
     event.add("gregitas:eggs/dragon/fire", `iceandfire:dragonegg_${color}`)
   })

--- a/kubejs/startup_scripts/constants_startup.js
+++ b/kubejs/startup_scripts/constants_startup.js
@@ -64,6 +64,42 @@ const pkgJson = {
 	}
 }
 
+global.itemsToRemove = [
+	"tfc:metal/sheet/steel",
+	"immersiveengineering:plate_steel",
+	"vintageimprovements:andesite_sheet",
+	"alltheores:peridot",
+	`/^alltheores:.*_rod/`,
+	`/^alltheores:.*_dust/`,
+	`/^alltheores:.*_nugget/`,
+	`/^alltheores:.*_plate/`,
+	`/^alltheores:.*_gear/`,
+	`/^alltheores:.*_ore_hammer/`,
+	`/^alltheores:.*_block/`,
+	`/^alltheores:.*_ingot/`,
+	`/^alltheores:raw_.*/`,
+	`/^allthemodium:.*allthemodium.*/`,
+	`/^allthemodium:.*vibranium.*/`,
+	`/^allthemodium:.*unobtainium.*/`,
+	`/^allthemodium:alloy_.*/`,
+	`/^immersiveengineering:plate_.*/`,
+	`/^immersiveengineering:mold_.*/`,
+	`/^immersiveengineering:wire_.*/`,
+	`/^tfc_ie_addon:metal/sheet/.*/`,
+	`/^tfc:metal/sheet/.*/`,
+	]
+
+global.fluidsWithBucketsToRemove = [
+	"enderio:dew_of_the_void",
+]
+
+global.fluidsToRemove = [
+	"allthemodium:soul_lava",
+	"allthemodium:molten_allthemodium",
+	"allthemodium:molten_unobtainium",
+	"allthemodium:molten_vibranium",
+]
+
 global.gregVeins = [
 	{
 	  name: "apatite",


### PR DESCRIPTION
Feel free to review commit-by commit, rather than the whole thing at once.

- Add recipe + unhide framed double slab/panel 
- Hide ID squeezers
- Fix create connected fluid vessel needing vanilla barrel
- Vanilla book/quill now only needs black dye
- Glow inc bulk haunting now only needs black dye
- TFC saltpeter powder recipe fixes
- Misc mv quest fixups
- TFC salt water to salt heated mixing (worse efficiency than centrifuge)
- TFC stripped **wood** create sawing recipes
- TFC supports create sawing recipes (stripped logs only)
- Wrought Iron Ingots use Create superheated pressing (brilliant white), rather than NBT fIxes #480 
- Railcraft steel anvil uses solidifier
- Hid many unobtainable items (also removed their tags so they don't show in recipes, nice qol change)
- Unified immersive engineering + vintage improvements items (fixes igneous zinc alloy pressing)
- Coke bricks now only need regular clay rather than Fire Clay to allow early-game graphite
    - Chapter 2 quests adjusted to give player 2 options: graphite ore path, or coke path
- Fire clay knapping automation with Create Compacting