### PR TITLE
Adds TFC recipes for a few early game Gregtech alloys

### DIFF
--- a/kubejs/data/tfc/recipes/alloy/battery_alloy.json
+++ b/kubejs/data/tfc/recipes/alloy/battery_alloy.json
@@ -1,0 +1,16 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc_ie_addon:lead",
+      "max": 0.85,
+      "min": 0.75
+    },
+    {
+      "metal": "gtceu:antimony",
+      "max": 0.25,
+      "min": 0.15
+    }
+  ],
+  "result": "gtceu:battery_alloy"
+}

--- a/kubejs/data/tfc/recipes/alloy/cupronickel.json
+++ b/kubejs/data/tfc/recipes/alloy/cupronickel.json
@@ -1,0 +1,16 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc:copper",
+      "max": 0.80,
+      "min": 0.40
+    },
+    {
+      "metal": "tfc:nickel",
+      "max": 0.60,
+      "min": 0.20
+    }
+  ],
+  "result": "gtceu:cupronickel"
+}

--- a/kubejs/data/tfc/recipes/alloy/potin.json
+++ b/kubejs/data/tfc/recipes/alloy/potin.json
@@ -1,0 +1,21 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc:copper",
+      "max": 0.70,
+      "min": 0.65
+    },
+    {
+      "metal": "tfc:tin",
+      "max": 0.25,
+      "min": 0.20
+    },
+    {
+      "metal": "tfc_ie_addon:lead",
+      "max": 0.15,
+      "min": 0.10
+    }
+  ],
+  "result": "gtceu:potin"
+}

--- a/kubejs/data/tfc/recipes/alloy/potin_bronze.json
+++ b/kubejs/data/tfc/recipes/alloy/potin_bronze.json
@@ -1,0 +1,21 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc:bronze",
+      "max": 0.80,
+      "min": 0.75
+    },
+    {
+      "metal": "tfc:tin",
+      "max": 0.15,
+      "min": 0.10
+    },
+	{
+      "metal": "tfc_ie_addon:lead",
+      "max": 0.15,
+      "min": 0.10
+    }
+  ],
+  "result": "gtceu:potin"
+}

--- a/kubejs/data/tfc/recipes/alloy/soldering_alloy.json
+++ b/kubejs/data/tfc/recipes/alloy/soldering_alloy.json
@@ -1,0 +1,21 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc:tin",
+      "max": 0.70,
+      "min": 0.50
+    },
+    {
+      "metal": "tfc_ie_addon:lead",
+      "max": 0.35,
+      "min": 0.25
+    },
+    {
+      "metal": "gtceu:antimony",
+      "max": 0.12,
+      "min": 0.08
+    }
+  ],
+  "result": "gtceu:soldering_alloy"
+}

--- a/kubejs/data/tfc/recipes/alloy/tin_alloy.json
+++ b/kubejs/data/tfc/recipes/alloy/tin_alloy.json
@@ -1,0 +1,16 @@
+{
+  "type": "tfc:alloy",
+  "contents": [
+    {
+      "metal": "tfc:tin",
+      "max": 0.60,
+      "min": 0.40
+    },
+    {
+      "metal": "tfc:cast_iron",
+      "max": 0.60,
+      "min": 0.40
+    }
+  ],
+  "result": "gtceu:tin_alloy"
+}


### PR DESCRIPTION
This adds recipes for the following early game Gregtech alloys to TFC, making them available in vessels and crucibles:

* Potin (two recipes, one is basic, another allows for bronze to be recycled into potin)
* Soldering alloy
* Tin alloy
* Battery alloy
* Cupronickel (a bit tricky to make because of an overlap with Constantan - either add more than 60% copper, or melt an existing Cupronickel ingot to force it)