### PR TITLE
Makes Create machines produce Gregtech rods and plates more consistently

### DIFF
--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -11,6 +11,7 @@ ServerEvents.recipes((event) => {
   createAdd(event)
   centrifugeAdd(event)
   wiresAdd(event)
+  createMaterialProcessingAdd(event)
   coilingTweak(event)
   pressurizedBasinAdd(event)
   spaceDustChain(event)

--- a/kubejs/server_scripts/mods/create/materialProcessing.js
+++ b/kubejs/server_scripts/mods/create/materialProcessing.js
@@ -1,0 +1,57 @@
+const gtCreatePressablePlates = [
+	"wrought_iron", "black_bronze", "bismuth_bronze", "americium", "beryllium", "bismuth", "chromium",
+	"darmstadtium", "europium", "gallium", "iridium", "iron", "manganese", "molybdenum", "neodymium", 
+	"palladium", "plutonium_241", "rhodium", "ruthenium", "silicon", "tantalum", "thorium", "titanium",
+	"tungsten", "uranium_235", "naquadah", "enriched_naquadah", "naquadria", "neutronium", "tritanium",
+	"duranium", "trinium", "annealed_copper", "battery_alloy", "cupronickel", "kanthal", "magnalium",
+	"nichrome", "niobium_nitride", "niobium_titanium", "sterling_silver", "ruridit", "stainless_steel",
+	"tin_alloy", "ultimet", "vanadium_gallium", "yttrium_barium_cuprate", "graphene", "osmiridium",
+	"gallium_arsenide", "indium_gallium_phosphide", "magnetic_iron", "tungsten_carbide",
+	"indium_tin_barium_titanium_cuprate", "uranium_rhodium_dinaquadide", "enriched_naquadah_trinium_europium_duranide",
+	"black_steel", "damascus_steel", "tungsten_steel", "cobalt_brass", "magnetic_steel", "vanadium_steel",
+	"potin", "naquadah_alloy", "rhodium_plated_palladium", "red_steel", "blue_steel", "hssg", "red_alloy",
+	"hsse", "hsss", "blue_alloy", "tantalum_carbide", "hsla_steel", "molybdenum_disilicide", "zeron_100", 
+	"watertight_steel", "incoloy_ma_956", "maraging_steel_300", "hastelloy_x", "stellite_100", "titanium_carbide", 
+	"titanium_tungsten_carbide", "hastelloy_c_276"
+]
+
+const gtRollingIngots = [
+	"americium", "bismuth", "darmstadtium", "europium", "iridium", "manganese", "molybdenum", 
+	"neodymium", "palladium", "plutonium_241", "rhodium", "ruthenium", "samarium", "thorium",
+	"titanium", "tungsten", "uranium_235", "naquadah", "enriched_naquadah", "naquadria", "neutronium",
+	"tritanium", "duranium", "trinium", "annealed_copper", "battery_alloy", "cupronickel", "kanthal",
+	"magnalium", "nichrome", "niobium_nitride", "niobium_titanium", "sterling_silver", 
+	"black_bronze", "bismuth_bronze", "rtm_alloy", "ruridit", "tin_alloy", "ultimet", "vanadium_gallium",
+	"wrought_iron", "yttrium_barium_cuprate", "osmiridium", "nickel_zinc_ferrite", 
+	"magnetic_iron", "magnetic_neodymium", "magnetic_samarium", "black_steel", "damascus_steel", 
+	"tungsten_steel", "cobalt_brass", "magnetic_steel", "vanadium_steel", "potin", "naquadah_alloy",
+	"rhodium_plated_palladium", "red_steel", "blue_steel", "hssg", "red_alloy", "hsse", "hsss", 
+	"blue_alloy", "hsla_steel", "molybdenum_disilicide", "watertight_steel", "incoloy_ma_956", 
+	"maraging_steel_300", "hastelloy_x", "titanium_tungsten_carbide", "hastelloy_c_276"
+]
+
+let createMaterialProcessingAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
+	
+	// Add ingot -> plate recipes using Create press
+	gtCreatePressablePlates.forEach((material) => {
+		event.recipes.create.pressing(
+			`gtceu:${material}_plate`,
+			[`#forge:ingots/${material}`]
+		).id(`kubejs:pressing_${material}_plate`)
+	})
+	
+	// Add ingot -> 2x rod recipes using Create Crafts and Additions rolling mill
+	gtRollingIngots.forEach((material) => {
+		event.custom({
+			type: "createaddition:rolling",
+			input: {
+				tag: `forge:ingots/${material}`
+			},
+			result: {
+				item: `gtceu:${material}_rod`,
+				count: 2
+			}
+		}).id(`kubejs:rolling_${material}_rod`)
+	})
+	
+}

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -475,10 +475,6 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     results: [{ amount: 100, fluid: "createdieselgenerators:plant_oil" }]
   })
 
-  event.recipes.create.pressing("gtceu:wrought_iron_plate", ["#forge:ingots/wrought_iron"])
-  event.recipes.create.pressing("gtceu:black_bronze_plate", ["#forge:ingots/black_bronze"])
-  event.recipes.create.pressing("gtceu:bismuth_bronze_plate", ["#forge:ingots/bismuth_bronze"])
-
   colorMap.forEach((color) => {
     event
       .custom({
@@ -2676,18 +2672,6 @@ event.stonecutting("2x railways:riveted_locometal", "minecraft:iron_ingot")
     ],
     heatRequirement: "heated",
     results: [{ item: "createdieselgenerators:asphalt_block", amount: 4 }]
-  })
-
-  // Create Addition rolling
-  event.custom({
-    type: "createaddition:rolling",
-    input: {
-      item: "gtceu:potin_ingot"
-    },
-    result: {
-      item: "gtceu:potin_rod",
-      count: 2
-    },
   })
 
   event


### PR DESCRIPTION
This adds plate pressing (Create press) and rod rolling (Crafts and Additions rolling mill) recipes for pretty much every metal added by Gregtech.

It's good for consistency, and it makes early game Create workshops a bit more powerful.