### PR TITLE
Adds new recipes for making Create items using Gregtech materials

### DIFF
--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -12,6 +12,7 @@ ServerEvents.recipes((event) => {
   centrifugeAdd(event)
   wiresAdd(event)
   coilingTweak(event)
+  advancedCreateRecipes(event)
   pressurizedBasinAdd(event)
   spaceDustChain(event)
   certusSemiconductors(event)

--- a/kubejs/server_scripts/mods/create/advancedRecipes.js
+++ b/kubejs/server_scripts/mods/create/advancedRecipes.js
@@ -1,0 +1,118 @@
+let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
+	// Advanced and alternate recipes for Create machines and materials
+
+	// Recycling TFC quern parts into a Create millstone
+	event.recipes.minecraft.crafting_shaped("create:millstone", [" M ", " C ", " Q "], {
+		M: "tfc:handstone",
+		C: "create:cogwheel",
+		Q: "tfc:quern"
+	})
+	
+	// Coaxial gear variant - saves a shaft
+	event.recipes.minecraft.crafting_shaped("create:millstone", [" M ", " C ", " Q "], {
+		M: "tfc:handstone",
+		C: "petrolsparts:coaxial_gear",
+		Q: "tfc:quern"
+	})
+
+
+	// Making and upgrading gears with deployers
+	event.recipes.create.deploying("create:cogwheel", ["create:shaft", "#forge:treated_wood"])
+	event.recipes.create.deploying("create:large_cogwheel", ["create:cogwheel", "#forge:treated_wood"]) 
+	event.recipes.create.deploying("petrolsparts:large_coaxial_gear", ["petrolsparts:coaxial_gear", "#forge:treated_wood"]) 
+	
+	// A manual recipe too
+	event.shapeless("petrolsparts:large_coaxial_gear", ["petrolsparts:coaxial_gear", "#forge:treated_wood"])
+
+
+	// Making Rose Quartz in Gregtech Alloy Smelter 
+	// (uses just 4 redstone - manual crafting uses 8)
+	event.recipes.gtceu
+		.alloy_smelter("rose_quartz")
+		.itemInputs("#forge:gems/quartz", "4x minecraft:redstone")
+		.itemOutputs("create:rose_quartz")
+		.duration(50)
+		.EUt(16)
+
+
+	// Making Create belts using leather
+	event.recipes.minecraft.crafting_shaped("3x create:belt_connector", ["   ", "LLL", "MRM"], {
+		L: "#tfc:leather_knapping",
+		M: "tfc:brass_mechanisms",
+		R: "#forge:rods/wrought_iron"
+	})
+	event.recipes.minecraft.crafting_shaped("6x create:belt_connector", ["   ", "LLL", "MRM"], {
+		L: "#tfc:leather_knapping",
+		M: "#forge:gears/steel",
+		R: "#forge:rods/steel"
+	})
+	
+	// Making Create belts using Gregtech rubber sheets
+	event.recipes.minecraft.crafting_shaped("3x create:belt_connector", ["   ", "LLL", "MRM"], {
+		L: "#gregitas:any_rubber_sheet",
+		M: "tfc:brass_mechanisms",
+		R: "#forge:rods/wrought_iron"
+	})
+	event.recipes.minecraft.crafting_shaped("6x create:belt_connector", ["   ", "LLL", "MRM"], {
+		L: "#gregitas:any_rubber_sheet",
+		M: "#forge:gears/steel",
+		R: "#forge:rods/steel"
+	})
+
+	// Making Create spouts using Gregtech rubber rings
+	event.recipes.minecraft.crafting_shaped("create:spout", [" C ", " R ", "   "], {
+		C: "create:copper_casing",
+		R: "#gregitas:any_rubber_ring"
+	})
+
+
+	// Making Create funnels and tunnels using Gregtech rubber and plastic sheets
+	event.recipes.minecraft.crafting_shaped("2x create:andesite_funnel", [" A ", " S ", "   "], {
+		A: "create:andesite_alloy",
+		S: "#gregitas:any_rubber_sheet"
+	})
+	event.recipes.minecraft.crafting_shaped("2x create:andesite_funnel", [" A ", " S ", "   "], {
+		A: "create:andesite_alloy",
+		S: "#gregitas:any_rubber_or_plastic_thin_sheet"
+	})
+
+	event.recipes.minecraft.crafting_shaped("2x create:andesite_tunnel", ["AA ", "SS ", "   "], {
+		A: "create:andesite_alloy",
+		S: "#gregitas:any_rubber_sheet"
+	})
+	event.recipes.minecraft.crafting_shaped("2x create:andesite_tunnel", ["AA ", "SS ", "   "], {
+		A: "create:andesite_alloy",
+		S: "#gregitas:any_rubber_or_plastic_thin_sheet"
+	})
+
+	// Brass funnels and tunnels can use either Create electron tubes or Gregtech ULV circuits
+	event.recipes.minecraft.crafting_shaped("2x create:brass_funnel", [" C ", " B ", " S "], {
+		B: "#forge:ingots/brass",
+		S: "#gregitas:any_rubber_sheet",
+		C: "#gregitas:create_circuit"
+	})
+	event.recipes.minecraft.crafting_shaped("2x create:brass_funnel", [" C ", " B ", " S "], {
+		B: "#forge:ingots/brass",
+		S: "#gregitas:any_rubber_or_plastic_thin_sheet",
+		C: "#gregitas:create_circuit"
+	})
+	
+	event.recipes.minecraft.crafting_shaped("2x create:brass_tunnel", ["C  ", "BB ", "SS "], {
+		C: "#gregitas:create_circuit",
+		B: "#forge:ingots/brass",
+		S: "#gregitas:any_rubber_or_plastic_thin_sheet"
+	})
+	event.recipes.minecraft.crafting_shaped("2x create:brass_tunnel", ["C  ", "BB ", "SS "], {
+		C: "#gregitas:create_circuit",
+		B: "#forge:ingots/brass",
+		S: "#gregitas:any_rubber_or_plastic_thin_sheet"
+	})
+	
+	// Making a Create Diesel Generators pumpjack head using Gregtech rubber
+	event.recipes.minecraft.crafting_shaped("createdieselgenerators:pumpjack_head", ["A A", "ZSZ", "A A"], {
+		A: "create:andesite_alloy",
+		Z: "#forge:ingots/zinc",
+		S: "#gregitas:any_rubber_sheet"
+	})
+
+}

--- a/kubejs/server_scripts/mods/create/advancedRecipes.js
+++ b/kubejs/server_scripts/mods/create/advancedRecipes.js
@@ -19,7 +19,7 @@ let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
 	event.shapeless("petrolsparts:large_coaxial_gear", ["petrolsparts:coaxial_gear", "#forge:treated_wood"])
 
 
-	// Making Rose Quartz in Gregtech Alloy Smelter 
+	// Making Rose Quartz in GregTech Alloy Smelter 
 	// (uses just 4 redstone - manual crafting uses 8)
 	event.recipes.gtceu
 		.alloy_smelter("rose_quartz")
@@ -28,6 +28,14 @@ let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
 		.duration(50)
 		.EUt(16)
 
+	// Making Create Glue Tube in GregTech Assembler
+	event.recipes.gtceu
+		.assembler("super_glue")
+		.itemInputs("#forge:foils/wrought_iron")
+		.inputFluids(Fluid.of("gtceu:glue", 100))
+		.itemOutputs("create:super_glue")
+		.duration(60)
+		.EUt(16)
 
 	// Making Create belts using leather
 	event.recipes.minecraft.crafting_shaped("3x create:belt_connector", ["   ", "LLL", "MRM"], {

--- a/kubejs/server_scripts/mods/create/advancedRecipes.js
+++ b/kubejs/server_scripts/mods/create/advancedRecipes.js
@@ -133,4 +133,9 @@ let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
 	// Making a Create encased chain drive using TFC wrought iron chains
 	event.shapeless("create:encased_chain_drive", ["create:andesite_casing", "2x tfc:metal/chain/wrought_iron"])
 
+	// Replace the Create Mechanical Saw recipe with one using GT Iron Buzz Saw Blade
+	event.recipes.minecraft.crafting_shaped("create:mechanical_saw", [" B ", " C ", "   "], {
+		B: ["gtceu:iron_buzz_saw_blade", "gtceu:wrought_iron_buzz_saw_blade"],
+		C: "create:andesite_casing"
+	}).id('create:crafting/kinetics/mechanical_saw')
 }

--- a/kubejs/server_scripts/mods/create/advancedRecipes.js
+++ b/kubejs/server_scripts/mods/create/advancedRecipes.js
@@ -108,11 +108,35 @@ let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
 		S: "#gregitas:any_rubber_or_plastic_thin_sheet"
 	})
 	
+	// Making Create hose and elevator pulleys using Gregtech rubber
+	event.recipes.minecraft.crafting_shaped("create:hose_pulley", [" C ", " S ", " P "], {
+		C: "create:copper_casing",
+		S: "#gregitas:any_rubber_sheet",
+		P: "#forge:plates/copper"
+	})
+
+	event.recipes.minecraft.crafting_shaped("create:elevator_pulley", [" C ", " S ", " P "], {
+		C: "create:brass_casing",
+		S: "#gregitas:any_rubber_sheet",
+		P: "#forge:plates/wrought_iron"
+	})
+	
+	// Making a Create rope pulley using Firmaciv jute rope
+	event.recipes.minecraft.crafting_shaped("create:rope_pulley", [" C ", " S ", " P "], {
+		C: "create:andesite_casing",
+		S: "firmaciv:rope_coil",
+		P: "#forge:plates/wrought_iron"
+	})
+
+	
 	// Making a Create Diesel Generators pumpjack head using Gregtech rubber
 	event.recipes.minecraft.crafting_shaped("createdieselgenerators:pumpjack_head", ["A A", "ZSZ", "A A"], {
 		A: "create:andesite_alloy",
 		Z: "#forge:ingots/zinc",
 		S: "#gregitas:any_rubber_sheet"
 	})
+		
+	// Making a Create encased chain drive using TFC wrought iron chains
+	event.shapeless("create:encased_chain_drive", ["create:andesite_casing", "2x tfc:metal/chain/wrought_iron"])
 
 }

--- a/kubejs/server_scripts/mods/create/advancedRecipes.js
+++ b/kubejs/server_scripts/mods/create/advancedRecipes.js
@@ -2,19 +2,13 @@ let advancedCreateRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
 	// Advanced and alternate recipes for Create machines and materials
 
 	// Recycling TFC quern parts into a Create millstone
+	// The coaxial gear variant saves a shaft
 	event.recipes.minecraft.crafting_shaped("create:millstone", [" M ", " C ", " Q "], {
 		M: "tfc:handstone",
-		C: "create:cogwheel",
+		C: ["create:cogwheel", "petrolsparts:coaxial_gear"],
 		Q: "tfc:quern"
 	})
 	
-	// Coaxial gear variant - saves a shaft
-	event.recipes.minecraft.crafting_shaped("create:millstone", [" M ", " C ", " Q "], {
-		M: "tfc:handstone",
-		C: "petrolsparts:coaxial_gear",
-		Q: "tfc:quern"
-	})
-
 
 	// Making and upgrading gears with deployers
 	event.recipes.create.deploying("create:cogwheel", ["create:shaft", "#forge:treated_wood"])

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -555,11 +555,6 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
 
   //Create Start
 
-  shaped("create:millstone", [" M ", " G ", " Q "], {
-    M: "tfc:handstone",
-    G: "create:cogwheel",
-    Q: "tfc:quern"
-  })
   gemStonesA.forEach((gemStone) => {
     event.custom({
       type: "tfc:damage_inputs_shapeless_crafting",
@@ -614,37 +609,6 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       S: 'gtceu:saltpeter_dust'
     }
   )
-  event.custom({
-    type: "create:deploying",
-    ingredients: [
-      {
-        item: "create:shaft"
-      },
-      { tag: "forge:treated_wood" }
-    ],
-    results: [{ item: "create:cogwheel" }]
-  })
-  shaped("3x create:belt_connector", ["   ", "LLL", "MRM"], {
-    L: "#tfc:leather_knapping",
-    M: "tfc:brass_mechanisms",
-    R: "#forge:rods/wrought_iron"
-  })
-  shaped("6x create:belt_connector", ["   ", "LLL", "MRM"], {
-    L: "#tfc:leather_knapping",
-    M: "#forge:gears/wrought_iron",
-    R: "#forge:rods/steel"
-  })
-  event.custom({
-    type: "create:deploying",
-    ingredients: [
-      {
-        item: "create:cogwheel"
-      },
-      { tag: "forge:treated_wood" }
-    ],
-    results: [{ item: "create:large_cogwheel" }]
-  })
-  event.shapeless("petrolsparts:large_coaxial_gear", ["petrolsparts:coaxial_gear", "#forge:treated_wood"])
   //Create End
 
   //GTCEU Start

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -438,6 +438,17 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     event.add("create:upgrade_aquatic/coral", `tfc:coral/${coral}`)
   })
 
+  event.add("gregitas:any_rubber_ring", ["gtceu:rubber_ring", "gtceu:silicone_rubber_ring", "gtceu:styrene_butadiene_rubber_ring"])
+  event.add("gregitas:any_rubber_sheet", ["gtceu:rubber_plate", "gtceu:silicone_rubber_plate", "gtceu:styrene_butadiene_rubber_plate"])
+  event.add("gregitas:any_rubber_thin_sheet", ["gtceu:rubber_foil", "gtceu:silicone_rubber_foil", "gtceu:styrene_butadiene_rubber_foil"])
+  event.add("gregitas:any_plastic_thin_sheet", ["gtceu:polyvinyl_chloride_foil", "gtceu:polyphenylene_sulfide_foil", "gtceu:polybenzimidazole_foil", "gtceu:polyethylene_foil", "gtceu:polycaprolactam_foil", "gtceu:polytetrafluoroethylene_foil", "gcyr:kapton_k_foil", "gcyr:para_aramid_foil"])
+
+  event.add("gregitas:any_rubber_or_plastic_thin_sheet", "#gregitas:any_rubber_thin_sheet")
+  event.add("gregitas:any_rubber_or_plastic_thin_sheet", "#gregitas:any_plastic_thin_sheet")
+  
+  event.add("gregitas:create_circuit", "create:electron_tube")
+  event.add("gregitas:create_circuit", "#gtceu:circuits/ulv")
+
   event.add("forge:dusts/apatite", "tfcthermaldeposits:mineral/powder/apatite")
 
   event.add("gravitas:phantom", "minecraft:warped_fungus")


### PR DESCRIPTION
This makes Create stuff easier to make and automate at LV to MV, and also makes Create more interconnected with Gregtech.

New recipes:

* Rose Quartz can be smelted in Gregtech Alloy Smelter - this uses just 4 redstone, down from 8 you need for manual crafting
* Create belts, tunnels, pulleys and funnels can be crafted using Gregtech rubber sheets in place of kelp/leather
* Create tunnels and funnels can also be crafted using Gregtech rubber/plastic thin sheets
* Create spout can be crafted using Gregtech rubber rings
* Brass tunnels and funnels that use Gregtech rubber can also use Gregtech ULV circuits instead of the Create electron tube
* Chain drives can be crafted using 2x TFC wrought iron chains instead of 3x iron nuggets 
  * This adds up to 18mb of wrought iron instead of 48mb of iron - you can't automate TFC chains yet, but soon you will be able to
* Create rope pulley can now use jute rope instead of wool/leather
* Create mechanical saw now requires Gregtech iron/wrought iron saw blade - same material cost as before, but needs basic Gregtech hand tools to craft
* Create Glue Tube can now be made in GregTech assembler, using liquid glue and a wrought iron foil.