### PR TITLE
Makes GregTech wood barrels available earlier

### DIFF
--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -503,7 +503,7 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.recipes.kubejs
     .shaped("gtceu:wood_drum", ["mRs", "PWP", "PWP"], {
       m: "#forge:tools/files",
-      R: "gtceu:sticky_resin",
+      R: ["gtceu:sticky_resin", "firmalife:beeswax"],
       s: "#forge:tools/saws",
       P: "#minecraft:planks",
       W: ["gtceu:long_iron_rod", "gtceu:long_wrought_iron_rod"]

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -501,13 +501,14 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
 
   event.recipes.kubejs
     .shaped("gtceu:wood_drum", ["mRs", "PWP", "PWP"], {
-      m: "#forge:tools/mallets",
+      m: "#forge:tools/files",
       R: "gtceu:sticky_resin",
       s: "#forge:tools/saws",
       P: "#minecraft:planks",
-      W: "gtceu:long_wrought_iron_rod"
+      W: ["gtceu:long_iron_rod", "gtceu:long_wrought_iron_rod"]
     })
     .damageIngredient(["#forge:tools"])
+    .id("gtceu:shaped/wooden_barrel")
 
   event.recipes.kubejs.shaped("gtceu:lv_electric_motor", ["cwr", "wmw", "rwc"], {
     c: "gtceu:tin_single_cable",

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -503,7 +503,7 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.recipes.kubejs
     .shaped("gtceu:wood_drum", ["mRs", "PWP", "PWP"], {
       m: "#forge:tools/files",
-      R: ["gtceu:sticky_resin", "firmalife:beeswax"],
+      R: ["gtceu:sticky_resin", "firmalife:beeswax", "create:super_glue"],
       s: "#forge:tools/saws",
       P: "#minecraft:planks",
       W: ["gtceu:long_iron_rod", "gtceu:long_wrought_iron_rod"]

--- a/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
+++ b/kubejs/server_scripts/mods/gtceu/gtceuAdd.js
@@ -499,6 +499,7 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       .EUt(LV)
   })
 
+  event.remove({ id: "gtceu:shaped/wooden_barrel" })
   event.recipes.kubejs
     .shaped("gtceu:wood_drum", ["mRs", "PWP", "PWP"], {
       m: "#forge:tools/files",
@@ -508,7 +509,6 @@ let gtceuAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
       W: ["gtceu:long_iron_rod", "gtceu:long_wrought_iron_rod"]
     })
     .damageIngredient(["#forge:tools"])
-    .id("gtceu:shaped/wooden_barrel")
 
   event.recipes.kubejs.shaped("gtceu:lv_electric_motor", ["cwr", "wmw", "rwc"], {
     c: "gtceu:tin_single_cable",


### PR DESCRIPTION
Instead of a mallet, the crafting recipe now uses a file. It can also use beeswax or Create glue tube instead of resin. This allows for slightly earlier Coke Oven automation.

Not a big change, mostly just consistency with #466 - which changed GregTech wood pipes from mallet to file to make them available a bit earlier.