### PR TITLE
Bumps Diesel Generators canister capacity up

### DIFF
--- a/config/createdieselgenerators-server.toml
+++ b/config/createdieselgenerators-server.toml
@@ -1,0 +1,54 @@
+
+["Server Configs"]
+	#Maximum width of Oil Barrels
+	"Max Oil Barrel Width" = 3
+	#Canister Capacity in mB
+	"Capacity of Canisters" = 32000
+	#Canister Capacity Enchantment Capacity Addition in mB
+	"Capacity Addition of Capacity Enchantment in Canisters" = 64000
+	#Canister can be filled by spouts
+	"Canister can be filled by spouts" = true
+	#Capacity of Tools requiring Fluids in mB
+	"Capacity of Tools requiring Fluids" = 200
+	#Tool Capacity Enchantment Capacity Addition in mB
+	"Capacity Addition of Tools with Capacity Enchantment" = 10
+	#Combustibles do boom boom when on fire
+	"Combustibles blow up" = true
+
+	["Server Configs"."Diesel Engines"]
+		#Turbocharged Diesel Engine Speed Multiplier
+		"Turbocharged Diesel Engine Speed Multiplier" = 2.0
+		#Turbocharged Diesel Engine Burn Rate Multiplier
+		"Turbocharged Diesel Engine Burn Rate Multiplier" = 1.0
+		#Whenever Normal Diesel Engines are enabled
+		"Normal Diesel Engines" = true
+		#Whenever Modular Diesel Engines are enabled
+		"Modular Diesel Engines" = true
+		#Whenever Huge Diesel Engines are enabled
+		"Huge Diesel Engines" = true
+		#Whenever Diesel Engines can be filled with an Item
+		"Engines can be filled with a bucket" = false
+
+	["Server Configs"."Oil Config"]
+		#Whenever crude oil deposits are infinite
+		"Infinite oil deposits" = false
+		#Normal oil chunks oil amount multiplier
+		"Normal oil chunks oil amount multiplier" = 1.0
+		#High oil chunks oil amount multiplier
+		"High oil chunks oil amount multiplier" = 1.0
+		#Max Oil Scanner Level
+		"Max Oil Scanner Level" = 10000
+		#Normal oil chunks percentage
+		#Range: 0.0 ~ 100.0
+		"Normal oil chunks percentage" = 10.0
+		#High oil chunks percentage
+		#Range: 0.0 ~ 100.0
+		"High oil chunks percentage" = 10.0
+
+		["Server Configs"."Oil Config".Distillation]
+			#Whenever wide Distillation Towers go faster than the thin ones
+			"Wide Distillation Tower Distill Faster" = true
+			#Height of Distillation Tower level
+			#Range: 1 ~ 3
+			"Height of Distillation Tower level" = 1
+


### PR DESCRIPTION
This PR adds a Diesel Generators config, and bumps the default canister capacity up - from 4 buckets to 32 buckets. It also bumps up the capacity gain from enchanting - to 64 buckets per enchantment level.

Even a fully enchanted canister is still inferior in capacity to GregTech drums, and can't auto-output. And in early game, bronze drums have the same capacity, and are easier to obtain. This just makes it so those canisters don't completely suck.