### PR TITLE
Allows Vibrating Table to run LV Sifter recipes

### DIFF
--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -10,6 +10,7 @@ ServerEvents.recipes((event) => {
   gtceuAdd(event)
   createAdd(event)
   centrifugeAdd(event)
+  oreVibratingAdd(event)
   viSulfuricAcid(event)
   wiresAdd(event)
   addOreConversions(event)

--- a/kubejs/server_scripts/mods/create/oreVibratingAdd.js
+++ b/kubejs/server_scripts/mods/create/oreVibratingAdd.js
@@ -1,0 +1,12 @@
+let oreVibratingAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
+	// Import Gregtech sifter recipes
+	event.forEachRecipe({ mod: 'gtceu', type: 'gtceu:sifter'}, (recipe) => {
+		// UGLY HACKS are used here to wrangle Gregtech recipes
+		let recipe_json = JSON.parse(recipe.json)
+				
+		let input_item = recipe_json.inputs.item.filter((f) => f.content.type == 'gtceu:sized')[0].content
+		let output_items = recipe_json.outputs.item.map((item) => Item.of(item.content.ingredient.item, item.content.count).withChance(item.chance / 10000))
+
+		event.recipes.vintageimprovements.vibrating(output_items, input_item.ingredient, recipe_json.duration)
+	})
+}


### PR DESCRIPTION
Makes another Create machine more useful.

Sifter recipe outputs are chance based, and chances improve with tiers. So GregTech sifters are better at MV+.