### PR TITLE
Makes liquid fuels more consistent

### DIFF
--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -25,6 +25,7 @@ ServerEvents.recipes((event) => {
   gregifyAE2(event)
   gregifyLaserIO(event)
   replaceDisc(event)
+  blazeLiquidFuels(event)
 })
 
 LootJS.modifiers((event) => {

--- a/kubejs/server_scripts/mods/create/blazeLiquidFuels.js
+++ b/kubejs/server_scripts/mods/create/blazeLiquidFuels.js
@@ -1,0 +1,14 @@
+// Liquid fuel burning recipes for Blaze Burner with a Straw (Create Crafts & Additions)
+
+let blazeLiquidFuels = (/** @type {Internal.RecipesEventJS} */ event) => {
+	// Remove all existing liquid burning recipes
+	event.remove({type: "createaddition:liquid_burning"})
+	
+	// Add new ones, using the global fuel type table (see: startup_scripts/constants_startup.js)
+	global.liquidFuels.forEach(fuel => {
+		// Fuels that allow for superheated burn last for half the base duration
+		let divider = fuel.superheated ? 2 : 1
+		
+		event.recipes.createaddition.liquid_burning({fluidTag: fuel.tag, amount: 1000}, fuel.burn_ticks / divider).superheated(fuel.superheated === true)
+	})
+}

--- a/kubejs/startup_scripts/constants_startup.js
+++ b/kubejs/startup_scripts/constants_startup.js
@@ -392,6 +392,7 @@ global.gregVeins = [
 /*
 GLOBAL FUEL DATA
 Currently used by:
+    Multiblock steam boiler fluid burner (RailCraft)
     Blaze Burner with a Straw (Create Crafts & Additions)
 
 tag:

--- a/kubejs/startup_scripts/constants_startup.js
+++ b/kubejs/startup_scripts/constants_startup.js
@@ -388,3 +388,148 @@ global.gregVeins = [
 	  ]
 	}
   ]
+
+/*
+GLOBAL FUEL DATA
+Currently used by:
+
+tag:
+    Fluid tag (a tag, not an ID!)
+burn_ticks:
+    How many ticks (20 TPS) does 1000mb of fuel burn for 
+    (used by RailCraft and Create blaze burners)
+
+flags:
+superheated:
+    Whether the fuel gets a Create blaze burner into a blue "superheated" burn
+    (this also halves the "burn_ticks" duration when this fuel used in a blaze burner)
+thermal:
+    Whether the fuel works because it's hot, as opposed to because it burns well.
+    This restricts the fuel from being used in things like ICEs and gas turbines.
+gas:
+    Whether the fuel is a gas (unset means "fluid")
+*/
+global.liquidFuels = [
+  {
+    tag: "forge:creosote",
+    burn_ticks: 4 * 60 * 20
+  },
+  {
+    tag: "forge:plant_oil",
+    burn_ticks: 4 * 60 * 20
+  },
+  {
+    tag: "forge:methanol",
+    burn_ticks: 5 * 60 * 20
+  },
+  {
+    tag: "forge:ethanol",
+    burn_ticks: 6 * 60 * 20
+  },
+  {
+    tag: "forge:crude_oil",
+    burn_ticks: 8 * 60 * 20
+  },
+  {
+    tag: "forge:oil",
+    burn_ticks: 8 * 60 * 20
+  },
+  {
+    tag: "forge:oil_light",
+    burn_ticks: 8 * 60 * 20
+  },
+  {
+    tag: "forge:oil_heavy",
+    burn_ticks: 8 * 60 * 20
+  },
+  {
+    tag: "forge:sulfuric_heavy_fuel",
+    burn_ticks: 14 * 60 * 20,
+    sulfuric: true
+  },
+  {
+    tag: "forge:sulfuric_light_fuel",
+    burn_ticks: 14 * 60 * 20,
+    sulfuric: true
+  },
+  {
+    tag: "forge:sulfuric_naphtha",
+    burn_ticks: 14 * 60 * 20,
+    sulfuric: true
+  },
+  {
+    tag: "forge:sulfuric_gas",
+    burn_ticks: 14 * 60 * 20,
+    sulfuric: true,
+    gas: true
+  },
+  {
+    tag: "forge:lava",
+    burn_ticks: 16 * 60 * 20 + 40,
+    thermal: true
+  },
+  {
+    tag: "forge:heavy_fuel",
+    burn_ticks: 30 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:light_fuel",
+    burn_ticks: 30 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:naphtha",
+    burn_ticks: 30 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:refinery_gas",
+    burn_ticks: 30 * 60 * 20,
+    superheated: true,
+    gas: true
+  },
+  {
+    tag: "forge:blaze",
+    burn_ticks: 30 * 60 * 20,
+    superheated: true,
+    thermal: true
+  },
+  {
+    tag: "forge:bio_diesel",
+    burn_ticks: 40 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:biofuel",
+    burn_ticks: 40 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:crude_diesel",
+    burn_ticks: 40 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:diesel",
+    burn_ticks: 80 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:gasoline",
+    burn_ticks: 80 * 60 * 20,
+	superheated: true
+  },
+  {
+    tag: "forge:cetane_boosted_diesel",
+    burn_ticks: 120 * 60 * 20,
+    superheated: true
+  },
+  {
+    tag: "forge:high_octane_gasoline",
+    burn_ticks: 160 * 60 * 20,
+    superheated: true
+  }
+]
+
+global.liquidFuelsCombustion = global.liquidFuels.filter(fuel => !fuel.thermal)

--- a/kubejs/startup_scripts/constants_startup.js
+++ b/kubejs/startup_scripts/constants_startup.js
@@ -392,6 +392,7 @@ global.gregVeins = [
 /*
 GLOBAL FUEL DATA
 Currently used by:
+    Blaze Burner with a Straw (Create Crafts & Additions)
 
 tag:
     Fluid tag (a tag, not an ID!)

--- a/kubejs/startup_scripts/main_startup.js
+++ b/kubejs/startup_scripts/main_startup.js
@@ -1,8 +1,5 @@
 // priority 0
 
-const $FuelUtil = Java.loadClass("mods.railcraft.api.fuel.FuelUtil")
-const $TagKey = Java.loadClass("net.minecraft.tags.TagKey")
-
 StartupEvents.init((e) => {
   if (!Platform.isClientEnvironment()) return
   $CustomClickEvent.register($UtilsJS.makeFunctionProxy("startup", $EventActor, handleFTBCustomClick))
@@ -32,12 +29,6 @@ StartupEvents.postInit((event) => {
 })
 
 StartupEvents.postInit((event) => {
-  $FuelUtil.fuelManager().addFuel($TagKey.create(Utils.getRegistry("fluid").key, "forge:creosote"), 4800)
-  $FuelUtil.fuelManager().addFuel($TagKey.create(Utils.getRegistry("fluid").key, "forge:crude_oil"), 18000)
-  $FuelUtil.fuelManager().addFuel($TagKey.create(Utils.getRegistry("fluid").key, "forge:ethanol"), 32000)
-  $FuelUtil.fuelManager().addFuel($TagKey.create(Utils.getRegistry("fluid").key, "forge:diesel"), 96000)
-  $FuelUtil.fuelManager().addFuel($TagKey.create(Utils.getRegistry("fluid").key, "forge:bio_diesel"), 96000)
-
   if (!Platform.isClientEnvironment()) return
   addTooltipToBlocks(event)
 })

--- a/kubejs/startup_scripts/post_init/railcraft_fuels.js
+++ b/kubejs/startup_scripts/post_init/railcraft_fuels.js
@@ -1,0 +1,11 @@
+const $FuelUtil = Java.loadClass("mods.railcraft.api.fuel.FuelUtil")
+const $TagKey = Java.loadClass("net.minecraft.tags.TagKey")
+
+StartupEvents.postInit((event) => {
+  const railcraftFuels = $FuelUtil.fuelManager()
+  const fluidRegistryKey = Utils.getRegistry("fluid").key
+  
+  global.liquidFuelsCombustion.forEach(fuel => {
+    railcraftFuels.addFuel($TagKey.create(fluidRegistryKey, fuel.tag), fuel.burn_ticks)
+  })
+})


### PR DESCRIPTION
RailCraft and Blaze Burner with a Straw now use the same global fuel type table.