### PR TITLE
Improves Chapter 3 quest

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschaptersnew3title.snbt
@@ -378,7 +378,14 @@
 			id: "62ECC24E927CF28D"
 			tasks: [{
 				id: "4E46DA34FF58420C"
-				item: "tfc:blowpipe"
+				item: {
+					Count: 1
+					id: "itemfilters:tag"
+					tag: {
+						value: "tfc:blowpipes"
+					}
+				}
+				title: "{gravitas.quest.stage3.blowpipe}"
 				type: "item"
 			}]
 			x: -2.5d
@@ -507,7 +514,6 @@
 			y: -1.0d
 		}
 		{
-			dependencies: ["35C75E911D6BDE12"]
 			id: "0E2E6B398D3F5CF1"
 			subtitle: "{gravitas.quest.stage3.subt.sanded}"
 			tasks: [
@@ -622,7 +628,14 @@
 			subtitle: "{gravitas.quest.stage3.subt.lime}"
 			tasks: [{
 				id: "3B18F0F1F1DE3CAB"
-				item: "tfc:powder/lime"
+				item: {
+					Count: 1
+					id: "itemfilters:tag"
+					tag: {
+						value: "forge:dusts/quicklime"
+					}
+				}
+				title: "{gravitas.quest.stage3.quicklime}"
 				type: "item"
 			}]
 			x: -2.5d
@@ -708,25 +721,12 @@
 			id: "19811B419D853CDF"
 			subtitle: "{gravitas.quest.stage3.subt.ash}"
 			tasks: [{
-				id: "21DE1255F5DE75D4"
+				id: "6799BEEFDF636807"
 				item: {
 					Count: 1
-					id: "itemfilters:or"
+					id: "itemfilters:tag"
 					tag: {
-						items: [
-							{
-								Count: 1b
-								id: "tfc:powder/saltpeter"
-							}
-							{
-								Count: 1b
-								id: "gtceu:saltpeter_dust"
-							}
-							{
-								Count: 1b
-								id: "tfc:powder/soda_ash"
-							}
-						]
+						value: "tfc:glassworking_potash"
 					}
 				}
 				title: "{gravitas.quest.stage3.subt.potash}"

--- a/kubejs/assets/gravitas/lang/en_us.json
+++ b/kubejs/assets/gravitas/lang/en_us.json
@@ -208,6 +208,8 @@
     "gravitas.quest.stage3.nickel": "Nickel",
     "gravitas.quest.stage3.silver": "Silver",
     "gravitas.quest.stage3.start": "&d&lLife Goes On",
+	"gravitas.quest.stage3.quicklime": "Quicklime",
+	"gravitas.quest.stage3.blowpipe": "Blowpipe",
 	"gravitas.quest.stage3.anvils": "Blue or Red Steel Anvil",
 
     "gravitas.quest.stage3.desc.ankh": "You can now farm Knowledge of Death!\\n\\nTry to remember to use your ankh on the grave whenever it's off cooldown.",


### PR DESCRIPTION
* Kimberlite diamond quest no longer strictly depends on black steel. Numerous skips are possible - kimberlite can be found in treasure chests or mined with things like Create drills.
* Multiple quest nodes now use item tags instead of hardcoded lists or sets, making them more robust.