### PR TITLE
Stargate recipe update

### DIFF
--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -1055,6 +1055,96 @@ let recipeAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
     .EUt(300000)
 
   //GTCEU End
+  
+  // sgjourney start
+
+  event.recipes.gtceu.chemical_bath("purified_naquadah")
+    .itemInputs("gtceu:naquadah_ingot")
+    .inputFluids("gregitas_core:sculk 144")
+    .itemOutputs("sgjourney:pure_naquadah")
+    .duration(20 * 25)
+    .EUt(IV)
+
+  event.recipes.gtceu.implosion_compressor("crystal_base_itnt")
+    .itemInputs("sgjourney:pure_naquadah", "gtceu:industrial_tnt")
+    .itemOutputs("sgjourney:crystal_base")
+    .duration(20)
+    .EUt(IV)
+  
+  event.recipes.gtceu.chemical_vapor_deposition("communication_crystal")
+    .itemInputs("sgjourney:crystal_base", "3x minecraft:quartz")
+    .inputFluids("gtceu:redstone 432")
+    .itemOutputs("sgjourney:communication_crystal")
+    .duration(20 * 15)
+    .EUt(IV)
+  
+  event.recipes.gtceu.chemical_vapor_deposition("transfer_crystal")
+    .itemInputs("sgjourney:crystal_base", "3x minecraft:glowstone_dust")
+    .inputFluids("gtceu:redstone 432")
+    .itemOutputs("sgjourney:transfer_crystal")
+    .duration(20 * 15)
+    .EUt(IV)
+  
+  event.recipes.gtceu.chemical_vapor_deposition("control_crystal")
+    .itemInputs("sgjourney:crystal_base", "3x tfc:gem/diamond")
+    .inputFluids("gtceu:redstone 432")
+    .itemOutputs("sgjourney:control_crystal")
+    .duration(20 * 15)
+    .EUt(IV)
+  
+  event.recipes.gtceu.chemical_vapor_deposition("materialization_crystal")
+    .itemInputs("sgjourney:crystal_base", "3x minecraft:ender_pearl")
+    .inputFluids("gtceu:redstone 432")
+    .itemOutputs("sgjourney:materialization_crystal")
+    .duration(20 * 15)
+    .EUt(IV)
+  
+  event.recipes.gtceu.chemical_vapor_deposition("energy_crystal")
+    .itemInputs("sgjourney:crystal_base", "3x minecraft:redstone")
+    .inputFluids("gtceu:redstone 432")
+    .itemOutputs("sgjourney:energy_crystal")
+    .duration(20 * 15)
+    .EUt(IV)
+  
+  event.recipes.gtceu.assembly_line("classic_stargate_ring_block")
+    .itemInputs("16x gtceu:uranium_triplatinum_single_wire", "4x gtceu:dense_tungsten_steel_plate", "2x gtceu:iv_conveyor_module", "gtceu:naquadah_alloy_frame")
+    .inputFluids("gtceu:soldering_alloy 576", "gtceu:polybenzimidazole 288")
+    .itemOutputs("sgjourney:classic_stargate_ring_block")
+    .duration(20 * 120)
+    .EUt(IV)
+  
+  event.recipes.gtceu.assembly_line("classic_stargate_chevron_block")
+    .itemInputs("64x gtceu:fine_hssg_wire", "8x gtceu:double_naquadah_plate", "4x #gtceu:circuits/luv", "2x gtceu:iv_conveyor_module", "sgjourney:transfer_crystal", "sgjourney:materialization_crystal", "sgjourney:energy_crystal", "gtceu:naquadah_alloy_frame")
+    .inputFluids("gtceu:soldering_alloy 576", "gtceu:polybenzimidazole 288")
+    .itemOutputs("sgjourney:classic_stargate_chevron_block")
+    ["scannerResearch(java.util.function.UnaryOperator)"]((b) =>
+      b.researchStack("sgjourney:classic_stargate_ring_block").EUt(IV).duration(20 * 60)
+    )
+    .duration(20 * 150)
+    .EUt(IV)
+  
+  event.recipes.gtceu.assembly_line("classic_stargate_base_block")
+    .itemInputs("32x gtceu:fine_osmiridium_wire", "16x gtceu:ruridit_gear", "12x gtceu:osmiridium_ring", "4x gtceu:naquadah_alloy_spring", "4x #gtceu:circuits/zpm", "4x gtceu:dense_naquadah_alloy_plate", "2x gtceu:luv_sensor", "2x gtceu:luv_emitter", "sgjourney:communication_crystal", "sgjourney:transfer_crystal", "sgjourney:control_crystal", "gtceu:naquadah_alloy_frame")
+    .inputFluids("gtceu:lubricant 4000", "gtceu:vanadium_gallium 1152", "gtceu:soldering_alloy 1152", "gtceu:polybenzimidazole 576")
+    .itemOutputs("sgjourney:classic_stargate_base_block")
+    ["scannerResearch(java.util.function.UnaryOperator)"]((b) =>
+      b.researchStack("sgjourney:classic_stargate_chevron_block").EUt(IV).duration(20 * 60)
+    )
+    .duration(20 * 180)
+    .EUt(IV)
+  
+  event.recipes.gtceu.assembly_line("classic_dhd")
+    .itemInputs("64x gtceu:fine_naquadah_wire", "4x gtceu:quantum_star", "4x gtceu:luv_field_generator", "4x gtceu:dense_naquadah_alloy_plate", "2x gtceu:luv_voltage_coil", "#gtceu:circuits/uv", "sgjourney:communication_crystal", "gtceu:naquadah_alloy_frame")
+    .inputFluids("gtceu:sodium_potassium 6000", "gtceu:lubricant 4000", "gtceu:styrene_butadiene_rubber 2304", "gtceu:soldering_alloy 1152")
+    .itemOutputs("sgjourney:classic_dhd")
+    ["scannerResearch(java.util.function.UnaryOperator)"]((b) =>
+      b.researchStack("sgjourney:classic_stargate_base_block").EUt(IV).duration(20 * 60)
+    )
+    .duration(20 * 450)
+    .EUt(IV)
+
+  // sgjourney end
+  
   //Computercraft
   shaped("computercraft:computer_normal", ["sps", "scs", "OPO"], {
     O: "gtceu:iron_plate",

--- a/kubejs/server_scripts/recipes/removal.js
+++ b/kubejs/server_scripts/recipes/removal.js
@@ -38,6 +38,18 @@ let recipeRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "vintageimprovements:curving/iron_sheet"})
   event.remove({ id: "vintageimprovements:rolling/andesite_plate"})
   event.remove({ id: "vintageimprovements:pressing/andesite_alloy"})
+  // sgjourney
+  event.remove({ id: "sgjourney:temp_pure_naquadah_from_blasting" })
+  event.remove({ id: "sgjourney:classic_stargate_base_block" })
+  event.remove({ id: "sgjourney:classic_stargate_chevron_block" })
+  event.remove({ id: "sgjourney:classic_stargate_ring_block" })
+  event.remove({ id: "sgjourney:crystallizing/communication_crystal" })
+  event.remove({ id: "sgjourney:crystallizing/transfer_crystal" })
+  event.remove({ id: "sgjourney:crystallizing/control_crystal" })
+  event.remove({ id: "sgjourney:crystallizing/materialization_crystal" })
+  event.remove({ id: "sgjourney:crystallizing/energy_crystal" })
+  event.remove({ id: "sgjourney:crystal_base" })
+  event.remove({ id: "sgjourney:classic_dhd" })
   //GT
   event.remove({ id: "gtceu:shaped/stick_wrought_iron" })
   event.remove({ id: "gtceu:cutter/cut_glass_block_to_plate_water"})

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -183,6 +183,9 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
     event.add("gregitas:eggs/dragon/lightning", `iceandfire:dragonegg_${color}`)
   })
 
+  // remove sgjourney tags
+  event.remove("forge:purified_ores/naquadah", "sgjourney:pure_naquadah")
+
   event.add("gravitas:igneous_rocks", ["#tfc:igneous_extrusive_rock", "#tfc:igneous_intrusive_rock"])
   event.add("forge:dusts/diamond", "tfc:powder/diamond")
   event.add("tfc:copper_pieces", [


### PR DESCRIPTION
- Removes the `forge:purified_ores/naquadah` item tag from `sgjourney:pure_naquadah`
- Replaces the recipes for the following items:
     - `sgjourney:classic_stargate_base_block`
     - `sgjourney:classic_stargate_chevron_block`
     - `sgjourney:classic_stargate_ring_block`
     - `sgjourney:classic_dhd`
     - `sgjourney:pure_naquadah`
     - `sgjourney:crystal_base`
     - `sgjourney:materialization_crystal`
     - `sgjourney:control_crystal`
     - `sgjourney:transfer_crystal`
     - `sgjourney:communication_crystal`

Stargates are effectively gated to GT's LuV age as well as having access to The Other