### PR TITLE
add #tfc:hammers to gtceu:tools/crafting_hammers

### DIFF
--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -198,6 +198,8 @@ const addItemTags = (/** @type {TagEvent.Item} */ event) => {
 
   event.add("forge:tools/saws", ["#tfc:saws"])
   event.add("forge:tools/hammers", "#tfc:hammers")
+  // turn tfc hammers into GT hammers, since there's no way to craft valid GT hammers otherwise
+  event.add("gtceu:tools/crafting_hammers", "#tfc:hammers")
   event.add("forge:tools/knives", ["#tfc:knives"])
 
   event.add("forge:tools", ["#forge:tools/saws", "#forge:tools/hammers", "#forge:tools/wrench", "#forge:tools/knives", "#forge:tools/files"])


### PR DESCRIPTION
In order to make it possible to use valid GT hammers which are otherwise uncraftable.

Specifically I needed this to make magnetic iron foil for crafting a magnetic ID chip for the gcyr rocket.

See https://discord.com/channels/254530689225981953/1454882215652622346/1459294572411748402 for details.
