### PR TITLE
Fixed non existent DFC metal block recipes being removed/created

### DIFF
--- a/kubejs/server_scripts/mods/dfc/dfc_constants.js
+++ b/kubejs/server_scripts/mods/dfc/dfc_constants.js
@@ -17,7 +17,9 @@ const dfcReplaceableMetals = [
   "blue_steel", "red_steel", "aluminum", "lead", "platinum"
 ]
 
-const dfcMetalsToRemove = ["lead", "aluminum", "alumina", "platinum"]
+const dfcCopyMetals = ["lead", "aluminum", "platinum"] 
+
+const dfcMetals = dfcCopyMetals.concat("alumina")
 
 const dfcAllMetals = dfcReplaceableMetals.concat(["cast_iron", "pewter", "alumina"])
 

--- a/kubejs/server_scripts/mods/dfc/dfc_recipes_removal.js
+++ b/kubejs/server_scripts/mods/dfc/dfc_recipes_removal.js
@@ -2,7 +2,7 @@
 
 const dfcRecipesRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   // Remove redundant DFC metal recipes
-  dfcMetalsToRemove.forEach((metal) => {
+  dfcMetals.forEach((metal) => {
     event.remove({ id: `dfc:welding/${metal}_double_ingot` })
     event.remove({ id: `dfc:anvil/${metal}_sheet` })
     event.remove({ id: `dfc:welding/${metal}_double_sheet` })

--- a/kubejs/server_scripts/mods/dfc/recipes_replace/metal_blocks.js
+++ b/kubejs/server_scripts/mods/dfc/recipes_replace/metal_blocks.js
@@ -1,5 +1,5 @@
 const dfcRecipesReplaceMetalBlocks = (/** @type {Internal.RecipesEventJS} */ event) => {
-  
+
   // Map of metals with different naming between DFC and GregTech
   const metalNameMap = {
     "aluminum": "aluminium"
@@ -25,7 +25,10 @@ const dfcRecipesReplaceMetalBlocks = (/** @type {Internal.RecipesEventJS} */ eve
     event.remove({ id: `dfc:crafting/metal/cut/${metal}` })
     event.remove({ id: `dfc:crafting/metal/smooth/${metal}` })
     event.remove({ id: `dfc:crafting/metal/pillar/${metal}` })
-    event.remove({ id: `dfc:crafting/metal/block/${metal}` })
+
+    if (dfcCopyMetals.includes(metal)) {
+      event.remove({ id: `dfc:crafting/metal/block/${metal}` })
+    }
 
     // Recreate with plate tags
     event.custom({
@@ -80,18 +83,20 @@ const dfcRecipesReplaceMetalBlocks = (/** @type {Internal.RecipesEventJS} */ eve
       }
     }).id(`kubejs:dfc/metal/pillar/${metal}`)
 
-    event.custom({
-      type: 'tfc:damage_inputs_shapeless_crafting',
-      recipe: {
-        type: 'minecraft:crafting_shapeless',
-        ingredients: [
-          { tag: `forge:plates/${gtMetal}` },
-          { tag: 'tfc:rock/smooth' },
-          { tag: 'tfc:hammers' }
-        ],
-        result: { item: `dfc:metal/block/${metal}`, count: 8 }
-      }
-    }).id(`kubejs:dfc/metal/block/${metal}`)
+    if (dfcCopyMetals.includes(metal)) {
+      event.custom({
+        type: 'tfc:damage_inputs_shapeless_crafting',
+        recipe: {
+          type: 'minecraft:crafting_shapeless',
+          ingredients: [
+            { tag: `forge:plates/${gtMetal}` },
+            { tag: 'tfc:rock/smooth' },
+            { tag: 'tfc:hammers' }
+          ],
+          result: { item: `dfc:metal/block/${metal}`, count: 8 }
+        }
+      }).id(`kubejs:dfc/metal/block/${metal}`)
+    }
   })
 
 }


### PR DESCRIPTION
It was trying to create a metal/block recipe for all the metal types, but DFC only has it for the metal types DFC adds, so I added a check to avoid trying to remove and create metal/block recipes for anything but the metals DFC adds.