### PR TITLE
Remove spawn books

### DIFF
--- a/config/Advancedperipherals/world.toml
+++ b/config/Advancedperipherals/world.toml
@@ -1,0 +1,13 @@
+
+#Config to adjust world settings
+[World]
+	#Enable the villager structures for the computer scientist.
+	enableVillagerStructures = true
+	#Gives the ap documentation to new players.
+	givePlayerBookOnJoin = false
+	#The weight of the villager structures.
+	#Range: 0 ~ 16000
+	villagerStructureWeight = 10
+	#Enable new wandering trader trades.
+	enableWanderingTraderTrades = true
+

--- a/config/integrateddynamics-common.toml
+++ b/config/integrateddynamics-common.toml
@@ -173,7 +173,7 @@
 
 	[item.on_the_dynamics_of_integration]
 		#If the info book should automatically obtained when the player first spawns.
-		obtainOnSpawn = true
+		obtainOnSpawn = false
 		#If the info book can give item rewards for tutorial completion.
 		bookRewards = true
 


### PR DESCRIPTION
Stops the AdvancedPeripherals & IntegratedDynamics books from spawning.