### PR TITLE
NC To GT Bridges: Finale

### DIFF
--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -14,6 +14,7 @@ ServerEvents.recipes((event) => {
   recipesTFCGlassblowingLenses(event)
   gtceuAdd(event)
   ncBridges(event)
+  ncRecipesAdd(event)
   createAdd(event)
   centrifugeAdd(event)
   tfcRecipesAdd(event)

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_assembler.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_assembler.js
@@ -1,0 +1,267 @@
+// priority 10
+
+// =============================================================================
+// NC → GT Assembler Recipe Bridge
+//
+// Bridges two groups of nuclearcraft:assembler recipes to GT:
+//
+// 1. Fuel recipes  (path starts with "fuel_")  → GT forming_press
+//    NC assembler: fuel pellet + cladding materials → TRISO-coated fuel
+//    GT forming_press: same inputs → same output, HV tier
+//
+// 2. Dust recipes  (path contains "dust", excluding fuel_ prefix)  → GT mixer
+//    NC assembler: multiple dust/item inputs → alloy product
+//    GT mixer: same inputs → same output, LV tier
+//
+// Skipped recipes:
+//   - ae2_* (have native GT circuit_assembler recipes)
+//   - recipes where any input cannot be resolved
+//   - recipes with tag-based outputs (GT needs a concrete output item)
+// =============================================================================
+
+// --- Config ------------------------------------------------------------------
+
+const NC_ASM_FUEL_BASE_EUT = 512 // HV
+const NC_ASM_FUEL_BASE_DURATION = 200
+
+const NC_ASM_DUST_BASE_EUT = 32 // LV
+const NC_ASM_DUST_BASE_DURATION = 200
+
+const NC_ASM_EXCLUDED_PATHS = {
+  ae2_calculation_processor: true,
+  ae2_engineering_processor: true,
+  ae2_logic_processor: true,
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Converts one NC assembler input entry to a GT item ingredient string,
+ * or null if the entry cannot be resolved.
+ *
+ * {item: "nuclearcraft:X", count: N} → "Nx nuclearcraft:X"
+ * {tag: "forge:dusts/graphite"}      → "#forge:dusts/graphite"
+ */
+function ncAsmInputStr(entry) {
+  if (!entry) {
+    return null
+  }
+  var prefix = entry.count && entry.count > 1 ? entry.count + "x " : ""
+  if (entry.item) {
+    return prefix + String(entry.item)
+  }
+  if (entry.tag) {
+    return prefix + "#" + String(entry.tag)
+  }
+  return null
+}
+
+/**
+ * Converts one NC assembler output entry to a concrete GT item output string,
+ * or null if the entry cannot be resolved.
+ *
+ * {item: "nuclearcraft:X", count: N} → "Nx nuclearcraft:X"
+ * {tag: "forge:dusts/X"}             → "gtceu:X_dust" or "nuclearcraft:X_dust"
+ * other tags                         → null
+ */
+function ncAsmOutputStr(entry) {
+  if (!entry) {
+    return null
+  }
+  var prefix = entry.count && entry.count > 1 ? entry.count + "x " : ""
+  if (entry.item) {
+    return prefix + String(entry.item)
+  }
+  if (entry.tag) {
+    var tagStr = String(entry.tag)
+    var dustMatch = tagStr.match(/^forge:dusts\/(.+)$/)
+    if (dustMatch) {
+      var material = dustMatch[1]
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("gtceu", String(material) + "_dust"))) {
+        return prefix + "gtceu:" + material + "_dust"
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("nuclearcraft", String(material) + "_dust"))) {
+        return prefix + "nuclearcraft:" + material + "_dust"
+      }
+    }
+    return null // unresolvable tag
+  }
+  return null
+}
+
+var ncFuelPressRegisteredIds = {}
+var ncAsmMixRegisteredIds = {}
+
+// --- Fuel: NC Assembler → GT Forming Press -----------------------------------
+
+let ncAssemblerFuelToGtFormingPress = (/** @type {Internal.RecipesEventJS} */ event) => {
+  let converted = 0
+  let skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:assembler" }, (recipe) => {
+    const ncPath = String(recipe.id).replace("nuclearcraft:assembler/", "")
+
+    if (ncPath.indexOf("fuel_") !== 0) return // only fuel recipes
+
+    if (NC_ASM_EXCLUDED_PATHS[ncPath]) {
+      skipped++
+      return
+    }
+
+    let json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      skipped++
+      return
+    }
+
+    // Unwrap forge:conditional if present
+    if (json.type === "forge:conditional" && json.recipes && json.recipes[0]) {
+      json = json.recipes[0].recipe
+    }
+
+    // --- Inputs ---
+    const rawInputs = Array.isArray(json.input) ? json.input : json.input != null ? [json.input] : []
+    if (rawInputs.length === 0) {
+      skipped++
+      return
+    }
+
+    var itemInputs = []
+    var inputsOk = true
+    for (var ii = 0; ii < rawInputs.length; ii++) {
+      var inStr = ncAsmInputStr(rawInputs[ii])
+      if (!inStr) {
+        inputsOk = false
+        break
+      }
+      itemInputs.push(inStr)
+    }
+    if (!inputsOk) {
+      skipped++
+      return
+    }
+
+    // --- Output ---
+    const rawOutputs = Array.isArray(json.output) ? json.output : json.output != null ? [json.output] : []
+    const outStr = ncAsmOutputStr(rawOutputs[0])
+    if (!outStr) {
+      skipped++
+      return
+    }
+
+    // --- Power / time ---
+    const powerModifier = Number(json.powerModifier) || 1.0
+    const timeModifier = Number(json.timeModifier) || 1.0
+    const eut = Math.round(NC_ASM_FUEL_BASE_EUT * powerModifier)
+    const duration = Math.round(NC_ASM_FUEL_BASE_DURATION * timeModifier)
+
+    // --- Recipe ID ---
+    const gtId = "gregitas:nc_fuel_press/" + ncPath.replace(/[^a-z0-9_.\-]/g, "_")
+
+    if (ncFuelPressRegisteredIds[gtId]) {
+      console.warn("[NC→GT FormingPress] ID collision: " + gtId + " (skipping " + recipe.id + ")")
+      skipped++
+      return
+    }
+    ncFuelPressRegisteredIds[gtId] = recipe.id
+
+    try {
+      event.recipes.gtceu.forming_press(gtId).itemInputs(itemInputs).itemOutputs(outStr).EUt(eut).duration(duration)
+      converted++
+    } catch (e) {
+      console.error("[NC→GT FormingPress] Failed: " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(`[NC→GT] FormingPress (fuel): ${converted} converted, ${skipped} skipped`)
+}
+
+// --- Dust: NC Assembler → GT Mixer -------------------------------------------
+
+let ncAssemblerDustToGtMixer = (/** @type {Internal.RecipesEventJS} */ event) => {
+  let converted = 0
+  let skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:assembler" }, (recipe) => {
+    const ncPath = String(recipe.id).replace("nuclearcraft:assembler/", "")
+
+    if (ncPath.indexOf("fuel_") === 0) return // fuel recipes handled by forming_press bridge
+
+    if (NC_ASM_EXCLUDED_PATHS[ncPath]) {
+      skipped++
+      return
+    }
+
+    let json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      skipped++
+      return
+    }
+
+    // Unwrap forge:conditional if present
+    if (json.type === "forge:conditional" && json.recipes && json.recipes[0]) {
+      json = json.recipes[0].recipe
+    }
+
+    // --- Output (resolve early to filter by output item ID) ---
+    const rawOutputs = Array.isArray(json.output) ? json.output : json.output != null ? [json.output] : []
+    const outStr = ncAsmOutputStr(rawOutputs[0])
+    if (!outStr || outStr.indexOf("dust") === -1) {
+      skipped++
+      return
+    }
+
+    // --- Inputs ---
+    const rawInputs = Array.isArray(json.input) ? json.input : json.input != null ? [json.input] : []
+    if (rawInputs.length === 0) {
+      skipped++
+      return
+    }
+
+    var itemInputs = []
+    var inputsOk = true
+    for (var ii = 0; ii < rawInputs.length; ii++) {
+      var inStr = ncAsmInputStr(rawInputs[ii])
+      if (!inStr) {
+        inputsOk = false
+        break
+      }
+      itemInputs.push(inStr)
+    }
+    if (!inputsOk) {
+      skipped++
+      return
+    }
+
+    // --- Power / time ---
+    const powerModifier = Number(json.powerModifier) || 1.0
+    const timeModifier = Number(json.timeModifier) || 1.0
+    const eut = Math.round(NC_ASM_DUST_BASE_EUT * powerModifier)
+    const duration = Math.round(NC_ASM_DUST_BASE_DURATION * timeModifier)
+
+    // --- Recipe ID ---
+    const gtId = "gregitas:nc_asm_mix/" + ncPath.replace(/[^a-z0-9_.\-]/g, "_")
+
+    if (ncAsmMixRegisteredIds[gtId]) {
+      console.warn("[NC→GT Mixer (asm)] ID collision: " + gtId + " (skipping " + recipe.id + ")")
+      skipped++
+      return
+    }
+    ncAsmMixRegisteredIds[gtId] = recipe.id
+
+    try {
+      event.recipes.gtceu.mixer(gtId).itemInputs(itemInputs).itemOutputs(outStr).EUt(eut).duration(duration)
+      converted++
+    } catch (e) {
+      console.error("[NC→GT Mixer (asm)] Failed: " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(`[NC→GT] Mixer (asm-dust): ${converted} converted, ${skipped} skipped`)
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_centrifuge.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_centrifuge.js
@@ -1,0 +1,155 @@
+// priority 10
+
+// =============================================================================
+// NC → GT Centrifuge Recipe Bridge (centrifuge)
+//
+// Reads all NuclearCraft centrifuge recipes and registers equivalent
+// GregTech centrifuge recipes. NC centrifuge is used primarily for isotope
+// separation: depleted fuel reprocessing, irradiated material separation,
+// and nuclear waste processing.
+//
+// Skipped:
+//   - any recipe ID containing "slurry" (handled by ore-processing chain)
+//   - explicit exclusion list (carbon_dioxide)
+//
+// NC powerModifier and timeModifier scale from the base EUt/duration below.
+// =============================================================================
+
+// --- Knobs -------------------------------------------------------------------
+
+// EV-tier — isotope separation is advanced nuclear work; sized to consume ~40%
+// of a good-sized fission reactor (2.5A EV ≈ 5120 EU/t output).
+const NC_CENT_BASE_EUT  = EV   // 2048 EU/t
+const NC_CENT_BASE_TIME = 900  // 20 seconds
+const NC_CENT_FLUID_SCALE = 144 / 90  // NC ingot = 90 mB, GT ingot = 144 mB
+
+// --- Exclusions --------------------------------------------------------------
+
+const NC_CENT_EXCLUDED_PATHS = {
+  carbon_dioxide: true,  // excluded by user
+  uranium:        true,  // manual recipe with corrected ratios
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Converts one NC centrifuge input fluid JSON entry to a FluidIngredientJS.
+ *
+ * NC depleted-fuel inputs use { "fluid": "nuclearcraft:depleted_fuel_..." }
+ * (a direct fluid ID, not a forge tag). All other inputs use { "tag": "forge:..." }.
+ * This helper handles both cases; for tag entries it delegates to ncInputFJI
+ * (shared from nc_to_gt_chem_reactor.js via priority-10 shared scope).
+ *
+ * @param {object} entry - NC fluid entry with .fluid or .tag, and .amount
+ * @param {number} scale - fluid amount scale factor (1.0 or NC_CENT_FLUID_SCALE)
+ * Returns null for invalid or zero-amount entries.
+ */
+function resolveNcCentrifugeInput(entry, scale) {
+  if (!entry || !entry.amount) {
+    return null
+  }
+  var amount = Number(entry.amount)
+  if (amount <= 0) {
+    return null
+  }
+  if (entry.fluid) {
+    return $FluidIngredientJS.of(String(entry.fluid) + " " + Math.round(amount * scale))
+  }
+  if (entry.tag) {
+    return ncInputFJI(entry, scale)
+  }
+  return null
+}
+
+// --- Main function -----------------------------------------------------------
+
+let ncCentrifugeToGtCentrifuge = (/** @type {Internal.RecipesEventJS} */ event) => {
+  var converted = 0
+  var slurrySkipped = 0
+  var excluded = 0
+  var skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:centrifuge" }, (recipe) => {
+    var ncPath = String(recipe.id).replace("nuclearcraft:centrifuge/", "")
+
+    if (ncPath.indexOf("slurry") >= 0) {
+      skipped++
+      return
+    }
+
+    if (NC_CENT_EXCLUDED_PATHS[ncPath]) {
+      excluded++
+      return
+    }
+
+    var json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      console.error("[NC→GT] Centrifuge: failed to parse JSON for " + recipe.id + " — " + e)
+      skipped++
+      return
+    }
+
+    // Resolve input fluid
+    var rawInFluids = Array.isArray(json.inputFluids) ? json.inputFluids : []
+    if (rawInFluids.length === 0) {
+      console.error("[NC→GT] Centrifuge: no inputFluids for " + recipe.id)
+      skipped++
+      return
+    }
+    // Scale fluid amounts 90→144 mB only for depleted fuel recipes
+    var isDepletedFuel = rawInFluids[0].fluid && String(rawInFluids[0].fluid).indexOf("depleted") >= 0
+    var fluidScale = isDepletedFuel ? NC_CENT_FLUID_SCALE : 1.0
+
+    var inputFJI = resolveNcCentrifugeInput(rawInFluids[0], fluidScale)
+    if (!inputFJI) {
+      console.error("[NC→GT] Centrifuge: null input FJI for " + recipe.id)
+      skipped++
+      return
+    }
+
+    // Resolve output fluids (all use forge tags)
+    var rawOutFluids = Array.isArray(json.outputFluids) ? json.outputFluids : []
+    if (rawOutFluids.length === 0) {
+      console.error("[NC→GT] Centrifuge: no outputFluids for " + recipe.id)
+      skipped++
+      return
+    }
+    var outputFJIs = []
+    for (var oi = 0; oi < rawOutFluids.length; oi++) {
+      var fji = ncOutputFJI(rawOutFluids[oi], fluidScale)
+      if (!fji) {
+        console.error("[NC→GT] Centrifuge: null output FJI at index " + oi + " for " + recipe.id)
+        skipped++
+        return
+      }
+      outputFJIs.push(fji)
+    }
+
+    var powerModifier = json.powerModifier != null ? Number(json.powerModifier) : 1.0
+    var timeModifier  = json.timeModifier  != null ? Number(json.timeModifier)  : 1.0
+    var eut      = Math.max(1, Math.round(NC_CENT_BASE_EUT  * powerModifier))
+    var duration = Math.max(1, Math.round(NC_CENT_BASE_TIME * timeModifier))
+
+    var gtId = "gregitas:nc_centrifuge/" + ncPath.replace(/[^a-z0-9_.\-]/g, "_")
+
+    try {
+      var r = event.recipes.gtceu.centrifuge(gtId)
+        .EUt(eut)
+        .duration(duration)
+      r.input($FluidRecipeCapability.CAP, inputFJI)
+      for (var ri = 0; ri < outputFJIs.length; ri++) {
+        r.output($FluidRecipeCapability.CAP, outputFJIs[ri])
+      }
+      converted++
+    } catch (e) {
+      console.error("[NC→GT] Centrifuge: failed to register " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(
+    `[NC→GT] Centrifuge: ${converted} converted, ${excluded} excluded, ${skipped} skipped`
+  )
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_crystallizer.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_crystallizer.js
@@ -95,7 +95,7 @@ let ncCrystallizerToGtCentrifuge = (/** @type {Internal.RecipesEventJS} */ event
     var ncPath = String(recipe.id).replace("nuclearcraft:crystallizer/", "")
 
     if (ncPath.indexOf("slurry") >= 0) {
-      slurrySkipped++
+      skipped++
       return
     }
 
@@ -167,6 +167,6 @@ let ncCrystallizerToGtCentrifuge = (/** @type {Internal.RecipesEventJS} */ event
   })
 
   console.log(
-    `[NC→GT] Crystallizer: ${converted} converted, ${slurrySkipped} slurry-skipped, ${excluded} excluded, ${skipped} skipped`
+    `[NC→GT] Crystallizer: ${converted} converted, ${excluded} excluded, ${skipped} skipped`
   )
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_crystallizer.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_crystallizer.js
@@ -1,0 +1,172 @@
+// priority 10
+
+// =============================================================================
+// NC → GT Centrifuge Recipe Bridge (crystallizer)
+//
+// Reads all NuclearCraft crystallizer recipes and registers equivalent
+// GregTech centrifuge recipes. Each NC recipe takes one input fluid
+// (a solution or extract) and produces one solid item. The GT equivalent
+// additionally outputs water equal to the input fluid amount, recovering
+// the solvent.
+//
+// Skipped:
+//   - any recipe ID containing "slurry" (handled by ore-processing chain)
+//   - explicit exclusion list (vanilla crystallization, non-solution fluids)
+//   - output cannot be resolved to a concrete item
+//
+// NC powerModifier and timeModifier scale from the base EUt/duration below.
+// =============================================================================
+
+// --- Knobs -------------------------------------------------------------------
+
+// Centrifuge: LV-tier — solution separation (mirrors the LV mixer forward direction).
+const NC_XTAL_BASE_EUT  = LV  // 32 EU/t
+const NC_XTAL_BASE_TIME = 100  // 5 seconds
+
+// --- Exclusions --------------------------------------------------------------
+
+const NC_XTAL_EXCLUDED_PATHS = {
+  polonium:                    true,  // output requires Mekanism (not in pack)
+  uranium_oxide:               true,  // excluded by user
+  water:                       true,  // excluded by user
+  redstone:                    true,  // excluded by user
+  potassium_iodide:            true,  // excluded by user ("potassium_iodine")
+  lapis:                       true,  // excluded by user
+  glowstone:                   true,  // excluded by user
+  sulfur:                      true,  // excluded by user
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Resolves an NC crystallizer output[] entry to a concrete GT item ID string
+ * (with optional count prefix), or null if unresolvable.
+ *
+ * { item: "any:id" }           → "any:id"  (accepts all namespaces)
+ * { item: "any:id", count: 2 } → "2x any:id"
+ * { tag: "forge:dusts/m" }     → "gtceu:m_dust"        if registered
+ *                              → "nuclearcraft:m_dust"  if registered
+ *                              → null otherwise
+ * other                        → null
+ */
+function resolveNcXtalOutput(output) {
+  if (!output) {
+    return null
+  }
+
+  if (output.item) {
+    var itemId = String(output.item)
+    var colon = itemId.indexOf(":")
+    if (colon < 0) return null
+    if (!$ForgeRegistries.ITEMS.containsKey(new $ResourceLocation(itemId.substring(0, colon), itemId.substring(colon + 1)))) {
+      return null
+    }
+    var count = output.count ? output.count : 1
+    return count > 1 ? count + "x " + itemId : itemId
+  }
+
+  if (output.tag) {
+    var tagPath = String(output.tag).replace(/^forge:/, "")
+    var dustMatch = tagPath.match(/^dusts\/(.+)$/)
+    if (dustMatch) {
+      var material = dustMatch[1]
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("gtceu", String(material) + "_dust"))) {
+        return "gtceu:" + material + "_dust"
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("nuclearcraft", String(material) + "_dust"))) {
+        return "nuclearcraft:" + material + "_dust"
+      }
+    }
+    return null
+  }
+
+  return null
+}
+
+// --- Main function -----------------------------------------------------------
+
+let ncCrystallizerToGtCentrifuge = (/** @type {Internal.RecipesEventJS} */ event) => {
+  var converted = 0
+  var slurrySkipped = 0
+  var excluded = 0
+  var skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:crystallizer" }, (recipe) => {
+    var ncPath = String(recipe.id).replace("nuclearcraft:crystallizer/", "")
+
+    if (ncPath.indexOf("slurry") >= 0) {
+      slurrySkipped++
+      return
+    }
+
+    if (NC_XTAL_EXCLUDED_PATHS[ncPath]) {
+      excluded++
+      return
+    }
+
+    var json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      console.error("[NC→GT] Crystallizer: failed to parse JSON for " + recipe.id + " — " + e)
+      skipped++
+      return
+    }
+
+    // Resolve fluid input
+    var rawInFluids = Array.isArray(json.inputFluids) ? json.inputFluids : []
+    if (rawInFluids.length === 0) {
+      console.error("[NC→GT] Crystallizer: no inputFluids for " + recipe.id)
+      skipped++
+      return
+    }
+    var inputFJI = ncInputFJI(rawInFluids[0], 1.0)
+    if (!inputFJI) {
+      console.error("[NC→GT] Crystallizer: null input FJI for " + recipe.id)
+      skipped++
+      return
+    }
+
+    // Resolve item output
+    var rawOutputs = Array.isArray(json.output) ? json.output : []
+    if (rawOutputs.length === 0) {
+      console.error("[NC→GT] Crystallizer: no output[] for " + recipe.id)
+      skipped++
+      return
+    }
+    var itemStr = resolveNcXtalOutput(rawOutputs[0])
+    if (!itemStr) {
+      console.error("[NC→GT] Crystallizer: unresolvable output for " + recipe.id)
+      skipped++
+      return
+    }
+
+    // Water output: same amount as input fluid
+    var waterAmount = rawInFluids[0].amount
+    var waterFJI = $FluidIngredientJS.of("minecraft:water " + waterAmount)
+
+    var powerModifier = json.powerModifier != null ? Number(json.powerModifier) : 1.0
+    var timeModifier  = json.timeModifier  != null ? Number(json.timeModifier)  : 1.0
+    var eut      = Math.max(1, Math.round(NC_XTAL_BASE_EUT  * powerModifier))
+    var duration = Math.max(1, Math.round(NC_XTAL_BASE_TIME * timeModifier))
+
+    var gtId = "gregitas:nc_xtal/" + ncPath.replace(/[^a-z0-9_.\-]/g, "_")
+
+    try {
+      var r = event.recipes.gtceu.centrifuge(gtId)
+        .itemOutputs(itemStr)
+        .EUt(eut)
+        .duration(duration)
+      r.input($FluidRecipeCapability.CAP, inputFJI)
+      r.output($FluidRecipeCapability.CAP, waterFJI)
+      converted++
+    } catch (e) {
+      console.error("[NC→GT] Crystallizer: failed to register " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(
+    `[NC→GT] Crystallizer: ${converted} converted, ${slurrySkipped} slurry-skipped, ${excluded} excluded, ${skipped} skipped`
+  )
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_fluid_enricher.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_fluid_enricher.js
@@ -1,0 +1,143 @@
+// priority 10
+
+// =============================================================================
+// NC → GT Mixer Recipe Bridge (fluid_enricher)
+//
+// Reads all NuclearCraft fluid_enricher recipes and registers equivalent
+// GregTech mixer recipes. Each NC recipe takes one solid item plus one input
+// fluid and produces one output fluid (dissolution / extraction reactions).
+//
+// NC powerModifier and timeModifier scale from the base EUt/duration constants
+// defined below.
+// =============================================================================
+
+// --- Knobs -------------------------------------------------------------------
+
+// Mixer: LV-tier — simple dust-dissolution chemistry (cf. limewater_from_flux).
+const NC_FE_BASE_EUT  = LV  // 32 EU/t
+const NC_FE_BASE_TIME = 100  // 5 seconds
+
+// --- Exclusions --------------------------------------------------------------
+//
+// NC fluid_enricher recipe paths to skip. Either handled elsewhere or excluded
+// at user request.
+
+const NC_FE_EXCLUDED_PATHS = {
+  "glowing_mushroom-redstone_ethanol": true,  // excluded by user
+  "dusts_iodine-potassium_hydroxide":  true,  // excluded by user
+  "dusts_uranium-oxygen":              true,  // excluded by user
+  "salt-water":                        true,  // excluded by user
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Sanitizes an NC fluid_enricher recipe ID into a GT recipe ID.
+ * e.g. "nuclearcraft:fluid_enricher/dusts_borax-water" → "gregitas:nc_fenrich/dusts_borax-water"
+ */
+function sanitizeFEId(ncId) {
+  var path = String(ncId)
+    .replace(/^[^:]+:/, "")
+    .replace(/^fluid_enricher\//, "")
+  return "gregitas:nc_fenrich/" + path.replace(/[^a-z0-9_.\-]/g, "_")
+}
+
+/**
+ * Resolves an NC fluid_enricher input[] entry to a KubeJS itemInputs string.
+ * { "tag": "forge:dusts/borax" }                       → "#forge:dusts/borax"
+ * { "item": "nuclearcraft:glowing_mushroom", "count": 3 } → "3x nuclearcraft:glowing_mushroom"
+ * { "item": "nuclearcraft:glowing_mushroom" }            → "nuclearcraft:glowing_mushroom"
+ * Returns null for unrecognised entries.
+ */
+function resolveFEItemInput(entry) {
+  if (!entry) {
+    return null
+  }
+  if (entry.tag) {
+    return "#" + String(entry.tag)
+  }
+  if (entry.item) {
+    var count = entry.count ? entry.count : 1
+    return count > 1 ? count + "x " + String(entry.item) : String(entry.item)
+  }
+  return null
+}
+
+// --- Main function -----------------------------------------------------------
+
+let ncFluidEnricherToGtMixer = (/** @type {Internal.RecipesEventJS} */ event) => {
+  var converted = 0
+  var excluded = 0
+  var skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:fluid_enricher" }, (recipe) => {
+    var ncPath = String(recipe.id).replace("nuclearcraft:fluid_enricher/", "")
+
+    if (NC_FE_EXCLUDED_PATHS[ncPath]) {
+      excluded++
+      return
+    }
+
+    var json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      console.error("[NC→GT] Fluid Enricher: failed to parse JSON for " + recipe.id + " — " + e)
+      skipped++
+      return
+    }
+
+    // Resolve item input
+    var rawInputs = Array.isArray(json.input) ? json.input : []
+    if (rawInputs.length === 0) {
+      console.error("[NC→GT] Fluid Enricher: no input[] for " + recipe.id)
+      skipped++
+      return
+    }
+    var itemStr = resolveFEItemInput(rawInputs[0])
+    if (!itemStr) {
+      console.error("[NC→GT] Fluid Enricher: unresolvable item input for " + recipe.id)
+      skipped++
+      return
+    }
+
+    // Resolve fluid input/output
+    var rawInFluids  = Array.isArray(json.inputFluids)  ? json.inputFluids  : []
+    var rawOutFluids = Array.isArray(json.outputFluids) ? json.outputFluids : []
+    if (rawInFluids.length === 0 || rawOutFluids.length === 0) {
+      console.error("[NC→GT] Fluid Enricher: missing fluids for " + recipe.id)
+      skipped++
+      return
+    }
+
+    var inputFJI  = ncInputFJI(rawInFluids[0],  1.0)
+    var outputFJI = ncOutputFJI(rawOutFluids[0], 1.0)
+    if (!inputFJI || !outputFJI) {
+      console.error("[NC→GT] Fluid Enricher: null FJI for " + recipe.id)
+      skipped++
+      return
+    }
+
+    var powerModifier = json.powerModifier != null ? Number(json.powerModifier) : 1.0
+    var timeModifier  = json.timeModifier  != null ? Number(json.timeModifier)  : 1.0
+    var eut      = Math.max(1, Math.round(NC_FE_BASE_EUT  * powerModifier))
+    var duration = Math.max(1, Math.round(NC_FE_BASE_TIME * timeModifier))
+
+    var gtId = sanitizeFEId(recipe.id)
+
+    try {
+      var r = event.recipes.gtceu.mixer(gtId)
+        .itemInputs(itemStr)
+        .EUt(eut)
+        .duration(duration)
+      r.input($FluidRecipeCapability.CAP, inputFJI)
+      r.output($FluidRecipeCapability.CAP, outputFJI)
+      converted++
+    } catch (e) {
+      console.error("[NC→GT] Fluid Enricher: failed to register " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(`[NC→GT] Fluid Enricher: ${converted} converted, ${excluded} excluded, ${skipped} skipped`)
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_macerator.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_macerator.js
@@ -1,0 +1,261 @@
+// priority 10
+
+// =============================================================================
+// NC → GT Macerator Recipe Bridge
+//
+// Reads all NuclearCraft manufactory recipes and registers equivalent
+// GregTech macerator recipes.
+//
+// NC manufactory accepts a solid item and creates a dust.
+// GT macerator does the same.
+//
+// Skipped recipes:
+//   - explicit skip list (porkchop, salmon, cod, sugar_cane, silicon_boule)
+//   - input item belongs to minecraft: namespace — GT macerator handles all vanilla
+//   - input item belongs to a non-nuclearcraft, non-minecraft namespace
+//   - input tag is forge:ingots/{m} and gtceu:{m}_ingot exists
+//   - input tag is forge:gems/{m}  and gtceu:{m}_gem  exists
+//   - output cannot be resolved to a concrete item
+//
+// Power: Math.round(LV * powerModifier)  EU/t
+// Time:  Math.round(200 * timeModifier)  ticks
+// =============================================================================
+
+// --- Config ------------------------------------------------------------------
+
+const NC_MA_BASE_DURATION = 200
+
+// NC manufactory recipe paths (everything after "nuclearcraft:manufactory/") to skip.
+const NC_MA_EXCLUDED_PATHS = {
+  // For making NC Gelatin, GT Gelatin will be used instead
+  porkchop:     true,
+  salmon:       true,
+  cod:          true,
+  // Bioplastic, to be replace by a new GT process
+  sugar_cane:   true,
+  // Will be replaced by GT silicon crafting
+  silicon_boule: true,
+  // Already handled in GT
+  gems_fluorite:    true,
+  // NC Ores
+  lithium_chunk:    true,
+  thorium_chunk:    true,
+  magnesium_chunk:  true,
+  uranium_chunk:    true,
+  boron_chunk:      true,
+  ingots_aluminum:  true,
+}
+
+// Ingot input bypass: NC ingots for these materials are always bridged to GT macerator,
+// even if a gtceu:{m}_ingot happens to be registered. The output dust is resolved by
+// resolveNcMaOutput (prefers gtceu:{m}_dust). No GT ingot exists for these in practice;
+// the bypass guard is a safety net against future GT material additions.
+const NC_MA_INGOT_BYPASS = {
+  "forge:ingots/sodium":    true,  // → gtceu:sodium_dust
+  "forge:ingots/lithium":   true,  // → gtceu:lithium_dust
+  "forge:ingots/magnesium": true,  // → gtceu:magnesium_dust
+  "forge:ingots/calcium":   true,  // → gtceu:calcium_dust
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Resolves an NC manufactory input entry to a GT item ingredient string,
+ * or null if the recipe should be skipped.
+ *
+ * {item: "nuclearcraft:X"} → "nuclearcraft:X"
+ * {item: "minecraft:X"}    → null  (GT handles all vanilla grinding)
+ * {item: "othermod:X"}     → null  (other mod owns it)
+ * {tag: "forge:ingots/m"}  → "#forge:ingots/m" if in NC_MA_INGOT_BYPASS (bypass GT check);
+ *                             null if gtceu:m_ingot exists;
+ *                             "#forge:ingots/m" if nuclearcraft:m_ingot registered
+ * {tag: "forge:gems/m"}    → null if gtceu:m_gem exists;
+ *                             "#forge:gems/m" if nuclearcraft:m_gem registered
+ * other tags               → null  (conservative)
+ */
+function resolveNcMaInput(input) {
+  if (!input) {
+    return null
+  }
+
+  if (input.item) {
+    const itemId = String(input.item)
+    const colon = itemId.indexOf(":")
+    if (colon < 0) {
+      return null
+    }
+    const ns = itemId.substring(0, colon)
+    if (ns === "nuclearcraft") {
+      return itemId
+    }
+    // minecraft: and all other namespaces → skip
+    return null
+  }
+
+  if (input.tag) {
+    const tagPath = String(input.tag).replace(/^forge:/, "")
+
+    const ingotMatch = tagPath.match(/^ingots\/(.+)$/)
+    if (ingotMatch) {
+      const material = ingotMatch[1]
+      const forgeTag = "forge:ingots/" + material
+      // Bypass the GT-ingot check for NC-only ingots that also happen to have a GT dust counterpart.
+      if (NC_MA_INGOT_BYPASS[forgeTag]) {
+	return "#" + forgeTag
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("gtceu", String(material) + "_ingot"))) {
+	return null
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("nuclearcraft", String(material) + "_ingot"))) {
+        return "#forge:ingots/" + material
+      }
+      return null
+    }
+
+    const gemMatch = tagPath.match(/^gems\/(.+)$/)
+    if (gemMatch) {
+      const material = gemMatch[1]
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("gtceu", String(material) + "_gem"))) {
+	return null
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("nuclearcraft", String(material) + "_gem"))) {
+        return "#forge:gems/" + material
+      }
+      return null
+    }
+
+    return null
+  }
+
+  return null
+}
+
+/**
+ * Resolves an NC manufactory output entry to a concrete GT item ID string,
+ * or null if the recipe should be skipped.
+ *
+ * {item: "nuclearcraft:X"} → "nuclearcraft:X"
+ * {item: "minecraft:X"}    → "minecraft:X"
+ * {item: "othermod:X"}     → null
+ * {tag: "forge:dusts/m"}   → "gtceu:m_dust"   if gtceu:m_dust exists  (prefer GT)
+ *                          → "nuclearcraft:m_dust" if nc:m_dust exists
+ *                          → null otherwise
+ * other tags               → null
+ */
+function resolveNcMaOutput(output) {
+  if (!output) {
+    return null
+  }
+
+  if (output.item) {
+    const itemId = String(output.item)
+    const colon = itemId.indexOf(":")
+    if (colon < 0) {
+      return null
+    }
+    const ns = itemId.substring(0, colon)
+    if (ns === "nuclearcraft" || ns === "minecraft") {
+      return itemId
+    }
+    return null
+  }
+
+  if (output.tag) {
+    const tagPath = String(output.tag).replace(/^forge:/, "")
+
+    const dustMatch = tagPath.match(/^dusts\/(.+)$/)
+    if (dustMatch) {
+      const material = dustMatch[1]
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("gtceu", String(material) + "_dust"))) {
+        return "gtceu:" + material + "_dust"
+      }
+      if ($ForgeRegistries.ITEMS.containsKey(new $ResourceLocation("nuclearcraft", String(material) + "_dust"))) {
+        return "nuclearcraft:" + material + "_dust"
+      }
+      return null
+    }
+
+    return null
+  }
+
+  return null
+}
+
+var ncMaRegisteredIds = {}
+
+// --- Main function -----------------------------------------------------------
+
+let ncManufactoryToGtMacerator = (/** @type {Internal.RecipesEventJS} */ event) => {
+  let converted = 0
+  let skipped = 0
+
+  event.forEachRecipe({ type: "nuclearcraft:manufactory" }, (recipe) => {
+    const ncPath = String(recipe.id).replace("nuclearcraft:manufactory/", "")
+
+    if (NC_MA_EXCLUDED_PATHS[ncPath]) {
+      skipped++
+      return
+    }
+
+    let json
+    try {
+      json = JSON.parse(recipe.json)
+    } catch (e) {
+      skipped++
+      return
+    }
+
+    // --- Input ---
+    const rawInputs = Array.isArray(json.input) ? json.input : (json.input != null ? [json.input] : [])
+    const inputEntry = rawInputs[0]
+    const inputItem = resolveNcMaInput(inputEntry)
+    if (!inputItem) {
+      skipped++
+      return
+    }
+    const inputCount = (inputEntry && inputEntry.count > 1) ? inputEntry.count : 1
+    const inputStr = inputCount > 1 ? (inputCount + "x " + inputItem) : inputItem
+
+    // --- Output ---
+    const rawOutputs = Array.isArray(json.output) ? json.output : (json.output != null ? [json.output] : [])
+    const outputEntry = rawOutputs[0]
+    const outputItem = resolveNcMaOutput(outputEntry)
+    if (!outputItem) {
+      skipped++
+      return
+    }
+    const outputCount = (outputEntry && outputEntry.count > 1) ? outputEntry.count : 1
+    const outputStr = outputCount > 1 ? (outputCount + "x " + outputItem) : outputItem
+
+    // --- Power / time ---
+    const powerModifier = Number(json.powerModifier) || 1.0
+    const timeModifier = Number(json.timeModifier) || 1.0
+    const eut = Math.round(LV * powerModifier)
+    const duration = Math.round(NC_MA_BASE_DURATION * timeModifier)
+
+    // --- Recipe ID ---
+    const gtId = "gregitas:nc_mace/" + ncPath.replace(/[^a-z0-9_.\-]/g, "_")
+
+    if (ncMaRegisteredIds[gtId]) {
+      console.warn("[NC→GT Macerator] ID collision: " + gtId + " (skipping " + recipe.id + ")")
+      skipped++
+      return
+    }
+    ncMaRegisteredIds[gtId] = recipe.id
+
+    try {
+      event.recipes.gtceu
+        .macerator(gtId)
+        .itemInputs(inputStr)
+        .itemOutputs(outputStr)
+        .EUt(eut)
+        .duration(duration)
+      converted++
+    } catch (e) {
+      console.error("[NC→GT Macerator] Failed: " + recipe.id + " — " + e)
+      skipped++
+    }
+  })
+
+  console.log(`[NC→GT] Macerator: ${converted} converted, ${skipped} skipped`)
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
@@ -9,4 +9,5 @@ let ncBridges = (/** @type {Internal.RecipesEventJS} */ event) => {
   ncMelterToGtExtractor(event)
   ncPressurizer(event)
   ncManufactoryToGtMacerator(event)
+  ncFluidEnricherToGtMixer(event)
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
@@ -10,4 +10,5 @@ let ncBridges = (/** @type {Internal.RecipesEventJS} */ event) => {
   ncPressurizer(event)
   ncManufactoryToGtMacerator(event)
   ncFluidEnricherToGtMixer(event)
+  ncCrystallizerToGtCentrifuge(event)
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
@@ -8,4 +8,5 @@ let ncBridges = (/** @type {Internal.RecipesEventJS} */ event) => {
   ncIngotFormerToGtSolidifier(event)
   ncMelterToGtExtractor(event)
   ncPressurizer(event)
+  ncManufactoryToGtMacerator(event)
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
@@ -11,4 +11,5 @@ let ncBridges = (/** @type {Internal.RecipesEventJS} */ event) => {
   ncManufactoryToGtMacerator(event)
   ncFluidEnricherToGtMixer(event)
   ncCrystallizerToGtCentrifuge(event)
+  ncCentrifugeToGtCentrifuge(event)
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_bridges.js
@@ -12,4 +12,6 @@ let ncBridges = (/** @type {Internal.RecipesEventJS} */ event) => {
   ncFluidEnricherToGtMixer(event)
   ncCrystallizerToGtCentrifuge(event)
   ncCentrifugeToGtCentrifuge(event)
+  ncAssemblerFuelToGtFormingPress(event)
+  ncAssemblerDustToGtMixer(event)
 }

--- a/kubejs/server_scripts/mods/nuclearcraft/nc_recipes_add.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/nc_recipes_add.js
@@ -1,0 +1,5 @@
+// priority 10
+
+const ncRecipesAdd = (/** @type {Internal.RecipesEventJS} */ event) => {
+  ncCentrifugeManual(event)
+}

--- a/kubejs/server_scripts/mods/nuclearcraft/recipes_add/centrifuge.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/recipes_add/centrifuge.js
@@ -1,0 +1,14 @@
+// priority 10
+
+// Manual NC centrifuge recipes bridged to GT centrifuge with corrected ratios.
+
+let ncCentrifugeManual = (/** @type {Internal.RecipesEventJS} */ event) => {
+  // Uranium isotope separation: 144 mB natural uranium → 128 mB U-238 + 16 mB U-235
+  // NC's default recipe has wrong isotope ratios; this corrects them.
+  var r = event.recipes.gtceu.centrifuge("gregitas:nc_centrifuge/uranium")
+    .EUt(EV)
+    .duration(900)
+  r.input($FluidRecipeCapability.CAP, $FluidIngredientJS.of("#forge:uranium 144"))
+  r.output($FluidRecipeCapability.CAP, $FluidIngredientJS.of("nuclearcraft:uranium_238 128"))
+  r.output($FluidRecipeCapability.CAP, $FluidIngredientJS.of("nuclearcraft:uranium_235 16"))
+}


### PR DESCRIPTION
Adds final four conversion files for the Fluid Enricher, Crystallizer, Centrifuge, and Assembler. The NC Electrolyzer has only one recipe needing conversion so I will do that manually at some point, and the NC Alloy Smelter needs more complex and varied recipe chains for the alloys which may include creating new intermediate materials, but I may revisit that and add an Alloy Smelter bridge once I have a clearer picture.

Fluid Enricher → GT Mixer                                                                                                                                                          
Bridged solution recipes, everything else was redundant or needs manual work.
- Base: LV, 100 ticks; scaled by powerModifier / timeModifier                                                                                                             
                  
Crystallizer → GT Centrifuge
Bridged de-solutioning recipes, slurry recipes skipped (we have multiple better ore processing chains), everything else was redundant or needs manual work.
- Base: LV, 100 ticks; scaled by powerModifier / timeModifier

Centrifuge → GT Centrifuge
Isotope separation and depleted fuel reprocessing. Depleted fuel fluids are rescaled 90 mB → 144 mB to match GT ingot volumes. Slurry recipes skipped, everything else was redundant or needs manual work. One manual recipe added: centrifuging natural Uranium (gtceu:uranium) has very incorrect ratios in the original recipe so it was remade with 144mb U → 128mb U238 16mb U235.
- Base: EV, 900 ticks; scaled by powerModifier / timeModifier

Assembler → GT Forming Press / Mixer
Bridged fuel and dust mixing recipes, the rest are redundant or need manual work.
Two sub-bridges, Both scaled by powerModifier / timeModifier:
- Fuel: GT Forming Press, HV, 200 ticks
- Dust: GT Mixer, LV, 200 ticks
