### PR TITLE
Immersive Geology Ore Gen

### DIFF
--- a/kubejs/client_scripts/lang/ig_ores.js
+++ b/kubejs/client_scripts/lang/ig_ores.js
@@ -1,0 +1,67 @@
+// priority 10
+
+var igOreNames = {
+  chalcopyrite: "Chalcopyrite",
+  cuprite:      "Cuprite",
+  galena:       "Galena",
+  pyrite:       "Pyrite",
+  acanthite:    "Acanthite",
+  apatite:      "Apatite",
+  bauxite:      "Bauxite",
+  chromite:     "Chromite",
+  cobaltite:    "Cobaltite",
+  fluorite:     "Fluorite",
+  ilmenite:     "Ilmenite",
+  molybdenite:  "Molybdenite",
+  pyrolusite:   "Pyrolusite",
+  scheelite:    "Scheelite",
+  smithsonite:  "Smithsonite",
+  vanadinite:   "Vanadinite",
+  wolframite:   "Wolframite",
+  anatase:      "Anatase",
+  chalcocite:   "Chalcocite",
+  lead:         "Lead",
+  millerite:    "Millerite",
+  thorianite:   "Thorianite",
+  uraninite:    "Uraninite",
+  monazite:     "Monazite",
+  thorite:      "Thorite",
+  zircon:       "Zircon",
+  platinum:     "Platinum",
+}
+
+var igAllStones = [
+  "andesite", "basalt", "dacite", "rhyolite",
+  "diorite", "gabbro", "granite",
+  "gneiss", "marble", "phyllite", "quartzite", "schist", "slate",
+  "chalk", "chert", "claystone", "conglomerate", "dolomite", "limestone", "shale",
+]
+
+var igRichness = [
+  { key: "poor",   label: "Poor" },
+  { key: "normal", label: "Normal" },
+  { key: "rich",   label: "Rich" },
+]
+
+const addIGOresLang = (/** @type {Internal.LangEventJS} */ event) => {
+  Object.keys(igOreNames).forEach((mineralId) => {
+    var name = igOreNames[mineralId]
+    igAllStones.forEach((stone) => {
+      var stoneName = stone.charAt(0).toUpperCase() + stone.slice(1)
+      igRichness.forEach((r) => {
+        var displayName = `${r.label} ${stoneName} ${name}`
+        var baseKey = `block.immersivegeology.tfc_${r.key}_ore_block_${mineralId}_${stone}`
+        event.add(baseKey, displayName)
+        event.add(`${baseKey}.prospected`, displayName)
+      })
+    })
+  })
+
+  // Zircon on the Moon uses the default Minecraft stone texture
+  event.add("block.immersivegeology.minecraft_poor_ore_block_zircon_stone", "Poor Zircon")
+  event.add("block.immersivegeology.minecraft_poor_ore_block_zircon_stone.prospected", "Poor Zircon")
+  event.add("block.immersivegeology.minecraft_normal_ore_block_zircon_stone", "Normal Zircon")
+  event.add("block.immersivegeology.minecraft_normal_ore_block_zircon_stone.prospected", "Normal Zircon")
+  event.add("block.immersivegeology.minecraft_rich_ore_block_zircon_stone", "Rich Zircon")
+  event.add("block.immersivegeology.minecraft_rich_ore_block_zircon_stone.prospected", "Rich Zircon")
+}

--- a/kubejs/client_scripts/main_client.js
+++ b/kubejs/client_scripts/main_client.js
@@ -28,6 +28,7 @@ ClientEvents.lang("en_us", (event) => {
   addGregitasName(event)
   convertBucketsToIngots(event)
   addRailwaysTFCNames(event)
+  addIGOresLang(event)
 })
 
 ItemEvents.tooltip(event => {

--- a/kubejs/client_scripts/patchouli/gravitas_book.js
+++ b/kubejs/client_scripts/patchouli/gravitas_book.js
@@ -40,6 +40,19 @@ let addTFCBookEntries = (/** @type {Internal.GenerateClientAssetsEventJS} */ eve
       multiblocks: patterns
     }
   }
+  const igFormationStones = {
+    IGNEOUS_INTRUSIVE: ["granite", "diorite", "gabbro"],
+    IGNEOUS_EXTRUSIVE: ["andesite", "basalt", "dacite", "rhyolite"],
+    SEDIMENTARY:       ["chalk", "chert", "claystone", "conglomerate", "dolomite", "limestone", "shale"],
+    METAMORPHIC:       ["gneiss", "marble", "phyllite", "quartzite", "schist", "slate"],
+  }
+  const igFormationLabel = {
+    IGNEOUS_INTRUSIVE: "Intrusive Igneous",
+    IGNEOUS_EXTRUSIVE: "Extrusive Igneous",
+    SEDIMENTARY:       "Sedimentary",
+    METAMORPHIC:       "Metamorphic",
+  }
+
   //Veins
   entry.put("name", "Gregtech Veins")
   entry.put("category", "tfc:gregitas")
@@ -81,13 +94,48 @@ let addTFCBookEntries = (/** @type {Internal.GenerateClientAssetsEventJS} */ eve
   entry.put("extra_recipe_mappings", mapping)
   event.add("tfc:patchouli_books/field_guide/en_us/entries/gregitas/greg_veins", entry)
 
+  //IG Ores
+  entry.clear()
+  entry.put("name", "Immersive Geology Ores")
+  entry.put("category", "tfc:gregitas")
+  entry.put("icon", "immersivegeology:normal_ore_copper")
+  entry.put("read_by_default", true)
+  entry.put("sortnum", 2)
+  pages.clear()
+  pages.add({
+    type: "patchouli:text",
+    text: "$(1)Immersive Geology$() adds its own ore veins that spawn in $(1)TerraFirmaCraft$() $(thing)rock$() types."
+  })
+  pages.add({
+    type: "patchouli:text",
+    text: "Navigate through the $(thing)Veins$() to find in which $(thing)rock$() types those veins spawn."
+  })
+  global.igBookData.forEach((ore) => {
+    let formationDesc = ore.formations
+      .map((f) => `$(li)$(thing)${igFormationLabel[f]}$(): ${igFormationStones[f].map((s) => Utils.snakeCaseToTitleCase(s)).join(", ")}`)
+      .join("")
+    let text = `Found between $(thing)y=${ore.minY}$() and $(thing)y=${ore.maxY}$().$(br)Spawns in:${formationDesc}`
+    pages.add(createTextPage(ore.name, text))
+    let blocks = Utils.newList()
+    ore.formations.forEach((f) => {
+      igFormationStones[f].forEach((stone) => {
+        let bl = `immersivegeology:tfc_normal_ore_block_${ore.id}_${stone}`
+        if (Item.exists(bl)) blocks.add(bl)
+        else console.log(`IG book: could not find block ${bl}`)
+      })
+    })
+    pages.add(createMultiblock(blocks, `Normal-quality ore blocks for $(thing)${ore.name}$().`))
+  })
+  entry.put("pages", pages)
+  event.add("tfc:patchouli_books/field_guide/en_us/entries/gregitas/ig_ores", entry)
+
   //Dragons
   entry.clear()
   entry.put("name", "Ice And Fire Dragons")
   entry.put("category", "tfc:gregitas")
   entry.put("icon", "iceandfire:dragon_skull_fire")
   entry.put("read_by_default", true)
-  entry.put("sortnum", 2)
+  entry.put("sortnum", 3)
   pages.clear()
   pages.add({
     type: "patchouli:text",

--- a/kubejs/data/immersivegeology/worldgen/placed_feature/anthracite.json
+++ b/kubejs/data/immersivegeology/worldgen/placed_feature/anthracite.json
@@ -1,6 +1,0 @@
-{
-  "feature": "immersivegeology:anthracite",
-  "placement": [
-    { "type": "minecraft:count", "count": 0 }
-  ]
-}

--- a/kubejs/data/immersivegeology/worldgen/placed_feature/bituminous.json
+++ b/kubejs/data/immersivegeology/worldgen/placed_feature/bituminous.json
@@ -1,6 +1,0 @@
-{
-  "feature": "immersivegeology:bituminous",
-  "placement": [
-    { "type": "minecraft:count", "count": 0 }
-  ]
-}

--- a/kubejs/data/immersivegeology/worldgen/placed_feature/lignite.json
+++ b/kubejs/data/immersivegeology/worldgen/placed_feature/lignite.json
@@ -1,6 +1,0 @@
-{
-  "feature": "immersivegeology:lignite",
-  "placement": [
-    { "type": "minecraft:count", "count": 0 }
-  ]
-}

--- a/kubejs/server_scripts/constants_server.js
+++ b/kubejs/server_scripts/constants_server.js
@@ -202,7 +202,16 @@ global.immGeoOres = [
   {
     ore:"uraninite",
     fluid:"tfc_ie_addon:metal/uranium"
-  }
+  },
+  { ore: "chalcocite",  fluid: "tfc:metal/copper" },
+  { ore: "cuprite",     fluid: "tfc:metal/copper" },
+  { ore: "galena",      fluid: "tfc_ie_addon:metal/lead" },
+  { ore: "acanthite",   fluid: "tfc:metal/silver" },
+  { ore: "chromite",    fluid: "gtceu:chromium" },
+  { ore: "thorite",     fluid: "gtceu:thorium" },
+  { ore: "thorianite",  fluid: "gtceu:thorium" },
+  { ore: "smithsonite", fluid: "tfc:metal/zinc" },
+  { ore: "millerite",   fluid: "tfc:metal/nickel" },
 ]
 
 global.immGeoOresMelts = {
@@ -217,9 +226,16 @@ global.immGeoOresMelts = {
   "cassiterite": 230,
   "magnetite": 1535,
   "sphalerite": 420,
-  "uraninite": 1132
-
-
+  "uraninite": 1132,
+  "chalcocite":  1080,
+  "cuprite":     1080,
+  "galena":      327,
+  "acanthite":   960,
+  "chromite":    1907,
+  "thorite":     1793,
+  "thorianite":  1793,
+  "smithsonite": 420,
+  "millerite":   1455,
 }
 
 global.immGeoOresCap = {
@@ -234,7 +250,16 @@ global.immGeoOresCap = {
   "cassiterite": 2.857,
   "magnetite": 1.143,
   "sphalerite": 1.905,
-  "uraninite": 1.143
+  "uraninite": 1.143,
+  "chalcocite":  1.143,
+  "cuprite":     1.143,
+  "galena":      1.143,
+  "acanthite":   0.833,
+  "chromite":    1.143,
+  "thorite":     0.667,
+  "thorianite":  0.667,
+  "smithsonite": 1.905,
+  "millerite":   1.143,
 }
 
 let enderTC = [

--- a/kubejs/server_scripts/datapack/ig_vein_gen.js
+++ b/kubejs/server_scripts/datapack/ig_vein_gen.js
@@ -1,0 +1,61 @@
+var stonesByFormation = {
+  IGNEOUS_EXTRUSIVE: ["andesite", "basalt", "dacite", "rhyolite"],
+  IGNEOUS_INTRUSIVE: ["diorite", "gabbro", "granite"],
+  METAMORPHIC:       ["gneiss", "marble", "phyllite", "quartzite", "schist", "slate"],
+  SEDIMENTARY:       ["chalk", "chert", "claystone", "conglomerate", "dolomite", "limestone", "shale"],
+}
+
+const addIGVeins = (/** @type {Internal.DataPackEventJS} */ event) => {
+  // Disable IG's own placed_features to prevent double-spawning.
+  global.igMineralData.minerals.forEach((mineral) => {
+    event.addJson(`immersivegeology:worldgen/placed_feature/${mineral.id}.json`, {
+      feature: `immersivegeology:${mineral.id}`,
+      placement: [{ type: "minecraft:count", count: 0 }],
+    })
+  })
+
+  const { minerals, globalMult } = global.igMineralData
+
+  minerals.forEach((mineral) => {
+    if (mineral.formations.length === 0) return
+
+    mineral.variants.forEach((variant) => {
+      var blocks = []
+      mineral.formations.forEach((formation) => {
+        var stones = stonesByFormation[formation]
+        if (!stones) return
+        stones.forEach((stone) => {
+          blocks.push({
+            replace: [`tfc:rock/raw/${stone}`],
+            with: [
+              { weight: variant.weights[0], block: `immersivegeology:tfc_poor_ore_block_${mineral.id}_${stone}` },
+              { weight: variant.weights[1], block: `immersivegeology:tfc_normal_ore_block_${mineral.id}_${stone}` },
+              { weight: variant.weights[2], block: `immersivegeology:tfc_rich_ore_block_${mineral.id}_${stone}` },
+            ],
+          })
+        })
+      })
+
+      var veinName = `ig_${mineral.id}_${variant.suffix}`
+      var rarity = Math.max(1, Math.round(variant.rarity / globalMult))
+
+      event.addJson(`gravitas2:worldgen/configured_feature/vein/${veinName}.json`, {
+        type: "tfc:cluster_vein",
+        config: {
+          rarity: rarity,
+          min_y: variant.minY,
+          max_y: variant.maxY,
+          size: variant.size,
+          density: variant.density,
+          blocks: blocks,
+          random_name: veinName,
+        },
+      })
+
+      event.addJson(`gravitas2:worldgen/placed_feature/vein/${veinName}.json`, {
+        feature: `gravitas2:vein/${veinName}`,
+        placement: [],
+      })
+    })
+  })
+}

--- a/kubejs/server_scripts/main_server.js
+++ b/kubejs/server_scripts/main_server.js
@@ -61,6 +61,7 @@ ServerEvents.tags("worldgen/biome", (event) => {
 ServerEvents.tags("worldgen/placed_feature", (event) => {
   addGregVeinsToTags(event)
   removeDFCOreVeins(event)
+  addIGOresToTags(event)
 })
 
 ServerEvents.tags("item", (event) => {
@@ -99,6 +100,7 @@ ServerEvents.lowPriorityData((event) => {
   addTFCPartHeatingRecipes(event)
   overrideTFCArmourFinalWeld(event)
   addGregVeinData(event)
+  addIGVeins(event)
   addGenericData(event)
   overrideTFCWorldPreset(event)
 })

--- a/kubejs/server_scripts/mods/immersive_engineering/ie_removal.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/ie_removal.js
@@ -51,6 +51,9 @@ let ieRecipesRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   // IE Crusher: c:raw_materials/* → dust conflicts with IG↔GT raw ore conversion
   event.remove({ id: /^immersiveengineering:crusher\/raw_ore_.*/ })
 
+  // IE Crusher: tfc_ie_addon default ore crusher recipes — replaced by TFC→IG conversions
+  event.remove({ id: /^tfc_ie_addon:crusher\/ore\/.*/ })
+
   event.remove({ id: "immersiveengineering:refinery/biodiesel" })
 
   event.remove({ id: /^immersiveengineering:crafting\/ingot.*to_nugget.*/})

--- a/kubejs/server_scripts/mods/immersive_geology/ig_constants.js
+++ b/kubejs/server_scripts/mods/immersive_geology/ig_constants.js
@@ -1,0 +1,269 @@
+// priority 10
+
+// -- IG ore generation config --------------------------------------------------
+// Each mineral has a `variants` array. Each variant produces one TFC cluster_vein.
+//   suffix   — appended to vein name: ig_<id>_<suffix>
+//   rarity   — 1-in-N chunk probability (lower = more common; TFC metals range ~7–120)
+//   size     — approximate ore block count per vein
+//   density  — fill fraction 0.0–1.0
+//   minY/maxY — Y bounds
+//   weights  — [poor, normal, rich] relative spawn weights
+//
+// Two-variant ores split at roughly Y 40–80:
+//   surface: shallower, poor-dominant (70/25/5), lower density
+//   deep:    richer ore body (35/40/25), higher density
+//   rich:    precious metals use (15/25/60) deep, like TFC native silver
+//
+// Raise globalMult to spawn more veins globally; lower it to spawn fewer.
+global.igMineralData = {
+  globalMult: 1.0,
+  minerals: [
+    // -- Copper ----------------------------------------------------------------
+    {
+      id: "chalcopyrite", value: "Chalcopyrite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 55,  size: 30, density: 0.50, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 70,  size: 25, density: 0.30, minY: 40,  maxY: 256, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "cuprite", value: "Cuprite",
+      formations: ["SEDIMENTARY", "IGNEOUS_EXTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 55,  size: 30, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 50,  size: 25, density: 0.30, minY: 40,  maxY: 256, weights: [70, 25, 5]  },
+      ],
+    },
+    // Used to make Osmium, so super rare in the overworld
+    {
+      id: "chalcocite", value: "Chalcocite",
+      formations: ["IGNEOUS_EXTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 580,  size: 18, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 560,  size: 20, density: 0.30, minY: 30,  maxY: 200, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Lead / Silver ---------------------------------------------------------
+    // DISABLED - We already have 2 galenas
+    {
+      id: "galena", value: "Galena",
+      // formations: ["METAMORPHIC"],
+      formations: [],
+      variants: [
+        { suffix: "deep",    rarity: 35,  size: 25, density: 0.50, minY: -64, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 50,  size: 18, density: 0.30, minY: 50,  maxY: 128, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "acanthite", value: "Acanthite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 70,  size: 22, density: 0.55, minY: -64, maxY: 80,  weights: [15, 25, 60] },
+        { suffix: "surface", rarity: 90,  size: 18, density: 0.30, minY: 40,  maxY: 212, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Iron sulfide ----------------------------------------------------------
+    // DISABLED - We already have 2 pyrites
+    {
+      id: "pyrite", value: "Pyrite",
+      // formations: ["METAMORPHIC", "SEDIMENTARY"],
+      formations: [],
+      variants: [
+        { suffix: "deep",    rarity: 30,  size: 25, density: 0.50, minY: -64, maxY: 60,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 45,  size: 20, density: 0.30, minY: 40,  maxY: 112, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Industrial minerals ---------------------------------------------------
+    {
+      id: "apatite", value: "Apatite",
+      formations: ["METAMORPHIC", "IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 80,  size: 25, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 95,  size: 20, density: 0.30, minY: 40,  maxY: 212, weights: [70, 25, 5]  },
+      ],
+    },
+    // DISABLED - We already have 2 Bauxites
+    {
+      id: "bauxite", value: "Bauxite",
+      // formations: ["SEDIMENTARY"],
+      formations: [],
+      variants: [
+        { suffix: "deep",    rarity: 70,  size: 22, density: 0.45, minY: -64, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 80,  size: 22, density: 0.35, minY: 40,  maxY: 180, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "fluorite", value: "Fluorite",
+      formations: ["IGNEOUS_INTRUSIVE", "IGNEOUS_EXTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 185,  size: 18, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 200,  size: 16, density: 0.30, minY: 40,  maxY: 220, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "pyrolusite", value: "Pyrolusite",
+      formations: ["SEDIMENTARY"],
+      variants: [
+        { suffix: "deep",    rarity: 85,  size: 22, density: 0.40, minY: -64, maxY: 60,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 95,  size: 20, density: 0.30, minY: 40,  maxY: 112, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Titanium --------------------------------------------------------------
+    {
+      id: "ilmenite", value: "Ilmenite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 170,  size: 22, density: 0.45, minY: 5,   maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 185,  size: 18, density: 0.30, minY: 50,  maxY: 140, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "anatase", value: "Anatase",
+      formations: ["IGNEOUS_INTRUSIVE", "IGNEOUS_EXTRUSIVE", "METAMORPHIC"],
+      variants: [
+        { suffix: "deep",    rarity: 170, size: 18, density: 0.40, minY: 20,  maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 185, size: 16, density: 0.25, minY: 50,  maxY: 180, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Chromium --------------------------------------------------------------
+    // DISABLED - We already have 2 Chromites
+    {
+      id: "chromite", value: "Chromite",
+      // formations: ["IGNEOUS_INTRUSIVE"],
+      formations: [],
+      variants: [
+        { suffix: "deep", rarity: 70, size: 22, density: 0.50, minY: -64, maxY: 24, weights: [35, 40, 25] },
+      ],
+    },
+    // -- Cobalt ----------------------------------------------------------------
+    {
+      id: "cobaltite", value: "Cobaltite",
+      formations: ["IGNEOUS_INTRUSIVE", "METAMORPHIC"],
+      variants: [
+        { suffix: "deep", rarity: 90, size: 20, density: 0.50, minY: -64, maxY: 72, weights: [35, 40, 25] },
+      ],
+    },
+    // -- Nickel ----------------------------------------------------------------
+    {
+      id: "millerite", value: "Millerite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 65,  size: 25, density: 0.50, minY: -64, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 85,  size: 16, density: 0.30, minY: 40,  maxY: 120, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Molybdenum / Tungsten -------------------------------------------------
+    {
+      id: "molybdenite", value: "Molybdenite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 180,  size: 20, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 200, size: 16, density: 0.30, minY: 40,  maxY: 212, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "scheelite", value: "Scheelite",
+      formations: ["SEDIMENTARY", "IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 210,  size: 20, density: 0.45, minY: -32, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 230, size: 16, density: 0.30, minY: 50,  maxY: 160, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "wolframite", value: "Wolframite",
+      formations: ["IGNEOUS_EXTRUSIVE", "IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 210,  size: 20, density: 0.45, minY: 0,   maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 230, size: 16, density: 0.30, minY: 50,  maxY: 192, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Vanadium / Zinc -------------------------------------------------------
+    {
+      id: "vanadinite", value: "Vanadinite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 105,  size: 20, density: 0.45, minY: -32, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 85,  size: 18, density: 0.30, minY: 50,  maxY: 140, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "smithsonite", value: "Smithsonite",
+      formations: ["SEDIMENTARY"],
+      variants: [
+        { suffix: "deep", rarity: 185, size: 18, density: 0.40, minY: 30, maxY: 70, weights: [35, 40, 25] },
+      ],
+    },
+    // -- Lead / Platinum (native) ---------------------------------------------------------
+    {
+      id: "lead", value: "Lead",
+      formations: ["SEDIMENTARY"],
+      variants: [
+        { suffix: "deep", rarity: 420, size: 16, density: 0.35, minY: 0, maxY: 50, weights: [35, 40, 25] },
+      ],
+    },
+    {
+      id: "platinum", value: "Platinum",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep", rarity: 380, size: 14, density: 0.45, minY: 10, maxY: 80, weights: [15, 25, 60] },
+      ],
+    },
+    // -- Zirconium -------------------------------------------------------------
+    {
+      id: "zircon", value: "Zircon",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 175,  size: 22, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 180,  size: 18, density: 0.30, minY: 40,  maxY: 200, weights: [70, 25, 5]  },
+      ],
+    },
+    // -- Radioactives ----------------------------------------------------------
+    // DISABLED - We already have 2 Uranninites
+    {
+      id: "uraninite", value: "Uraninite",
+      // formations: ["IGNEOUS_INTRUSIVE"],
+      formations: [],
+      variants: [
+        { suffix: "deep", rarity: 210, size: 18, density: 0.40, minY: -64, maxY: 32, weights: [35, 40, 25] },
+      ],
+    },
+    {
+      id: "thorianite", value: "Thorianite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 310, size: 18, density: 0.40, minY: -32, maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 340, size: 14, density: 0.25, minY: 50,  maxY: 128, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "monazite", value: "Monazite",
+      formations: ["SEDIMENTARY", "IGNEOUS_EXTRUSIVE"],
+      variants: [
+        { suffix: "deep",    rarity: 300, size: 18, density: 0.40, minY: 12,  maxY: 70,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 340, size: 16, density: 0.30, minY: 50,  maxY: 120, weights: [70, 25, 5]  },
+      ],
+    },
+    {
+      id: "thorite", value: "Thorite",
+      formations: ["IGNEOUS_INTRUSIVE"],
+      variants: [
+        { suffix: "deep", rarity: 520, size: 18, density: 0.40, minY: 0, maxY: 80, weights: [35, 40, 25] },
+      ],
+    },
+    // -- Disabled (no TFC ore blocks registered, or TFC/coal overlap) ----------
+    { id: "cryolite",    formations: [] },
+    { id: "hematite",    formations: [] },
+    { id: "magnetite",   formations: [] },
+    { id: "cassiterite", formations: [] },
+    { id: "sphalerite",  formations: [] },
+    { id: "copper",      formations: [] },
+    { id: "gypsum",      formations: [] },
+    { id: "silver",      formations: [] },
+    { id: "gold",        formations: [] },
+    { id: "unobtania",   formations: [] },
+    { id: "lignite",     formations: [] },
+    { id: "bituminous",  formations: [] },
+    { id: "anthracite",  formations: [] },
+  ],
+}

--- a/kubejs/server_scripts/mods/immersive_geology/ig_recipes_replace.js
+++ b/kubejs/server_scripts/mods/immersive_geology/ig_recipes_replace.js
@@ -12,4 +12,43 @@ var igRecipesReplace = (/** @type {Internal.RecipesEventJS} */ event) => {
   });
 
   event.replaceInput({ mod: "immersivegeology" }, "immersiveengineering:circuit_board", "gtceu:phenolic_circuit_board")
+
+  // Replace IE sulfur dust with GTCEu sulfur dust in IG sphalerite crusher recipes
+  event.remove({ id: /^immersivegeology:crushing\/crush_(poor|normal|rich)_ore_sphalerite.*/ })
+  event.custom({
+    type: "immersiveengineering:crusher",
+    energy: 6000,
+    input: { item: "immersivegeology:poor_ore_sphalerite" },
+    result: { item: "immersivegeology:dirty_crushed_ore_sphalerite" },
+    secondaries: [
+      { chance: 0.33,  output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+      { chance: 0.5,   output: { item: "gtceu:sulfur_dust" } },
+    ],
+    time: 100,
+  }).id("immersivegeology:crushing/crush_poor_ore_sphalerite_to_zincdirty_crushed_ore")
+  event.custom({
+    type: "immersiveengineering:crusher",
+    energy: 6000,
+    input: { item: "immersivegeology:normal_ore_sphalerite" },
+    result: { item: "immersivegeology:dirty_crushed_ore_sphalerite" },
+    secondaries: [
+      { chance: 0.33,  output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+      { chance: 0.5,   output: { item: "gtceu:sulfur_dust" } },
+      { chance: 0.165, output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+    ],
+    time: 100,
+  }).id("immersivegeology:crushing/crush_normal_ore_sphalerite_to_zincdirty_crushed_ore")
+  event.custom({
+    type: "immersiveengineering:crusher",
+    energy: 6000,
+    input: { item: "immersivegeology:rich_ore_sphalerite" },
+    result: { item: "immersivegeology:dirty_crushed_ore_sphalerite" },
+    secondaries: [
+      { chance: 0.33,  output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+      { chance: 0.5,   output: { item: "gtceu:sulfur_dust" } },
+      { chance: 0.165, output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+      { chance: 0.165, output: { item: "immersivegeology:dirty_crushed_ore_sphalerite" } },
+    ],
+    time: 100,
+  }).id("immersivegeology:crushing/crush_rich_ore_sphalerite_to_zincdirty_crushed_ore")
 }

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_conversion.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_conversion.js
@@ -1,13 +1,19 @@
 // IG ↔ GT ore processing conversion recipes
 // Design: each direction applies the *source* system's processing logic to the *target* system's machine
 //
-// IG → GT  (GT Macerator): IE Crusher odds applied to Macerator — yields GT crushed ore
-//   poor_ore   → 1× GT crushed + 33% chance of 1 more
-//   normal_ore → 1× GT crushed + 33% + 16.5% chances
-//   rich_ore   → 1× GT crushed + 33% + 16.5% + 16.5% chances
+// IG → GT  (GT Compressor): TFC→GT compression ratios applied to IG ore grades
+//   6× poor_ore   → 1× GT crushed
+//   4× normal_ore → 1× GT crushed
+//   3× rich_ore   → 1× GT crushed
 //
 // GT → IG  (IE Crusher): GT Macerator's 2× baseline + 10% bonus — averages 2.1× dirty crushed
 //   1× GT raw ore → 2× IG dirty crushed + 10% chance of 1 more (avg 2.1)
+//
+// TFC → IG  (IE Crusher): IG's native ore processing odds
+//   small  → 1× dirty crushed
+//   poor   → 1× dirty crushed + 33% chance of 1 more
+//   normal → 1× dirty crushed + 33% + 16.5% chances  (sphalerite: +50% sulfur dust)
+//   rich   → 1× dirty crushed + 33% + 16.5% + 16.5% (sphalerite: +50% sulfur dust)
 
 var ig_gt_ores = [
   { ig: "copper",       gt: "copper"           },
@@ -34,6 +40,21 @@ var ig_gt_ores = [
   { ig: "chalcocite",   gt: "chalcocite"       },
   { ig: "apatite",      gt: "apatite"          },
   { ig: "monazite",     gt: "monazite"         },
+  { ig: "fluorite",     gt: "fluorite",  ns: "gcyr" },
+]
+
+var tfc_ig_ores = [
+  { tfc: "native_copper", mod: "tfc",          ig: "copper"      },
+  { tfc: "native_gold",   mod: "tfc",          ig: "gold"        },
+  { tfc: "hematite",      mod: "tfc",          ig: "hematite"    },
+  { tfc: "native_silver", mod: "tfc",          ig: "silver"      },
+  { tfc: "cassiterite",   mod: "tfc",          ig: "cassiterite" },
+  { tfc: "magnetite",     mod: "tfc",          ig: "magnetite"   },
+  { tfc: "sphalerite",    mod: "tfc",          ig: "sphalerite",  sulfur: true },
+  { tfc: "bauxite",       mod: "tfc_ie_addon", ig: "bauxite"     },
+  { tfc: "galena",        mod: "tfc_ie_addon", ig: "galena"      },
+  { tfc: "uraninite",     mod: "tfc_ie_addon", ig: "uraninite"   },
+  { tfc: "chromite",      mod: "firmalife",    ig: "chromite"    },
 ]
 
 let addIgGtConversions = (/** @type {Internal.RecipesEventJS} */ event) => {
@@ -50,41 +71,48 @@ let addIgGtConversions = (/** @type {Internal.RecipesEventJS} */ event) => {
     ],
     time: 100,
   })
-  
-  ig_gt_ores.forEach((ore) => {
-    var gt_crushed = "gtceu:crushed_" + ore.gt + "_ore"
+
+  event.custom({
+    type: "immersiveengineering:crusher",
+    energy: 6000,
+    input: { item: "tfc:ore/gypsum" },
+    result: { item: "immersivegeology:dirty_crushed_ore_gypsum", count: 1 },
+    secondaries: [
+      { chance: 0.33, output: { item: "immersivegeology:dirty_crushed_ore_gypsum" } },
+      { chance: 0.165, output: { item: "immersivegeology:dirty_crushed_ore_gypsum" } }
+    ],
+    time: 100,
+  })
+
+  ig_gt_ores.forEach(function(ore) {
+    var ns = ore.ns || "gtceu"
+    var gt_crushed = ns + ":crushed_" + ore.gt + "_ore"
     var gt_raw = (ore.gt === "copper" || ore.gt === "gold")
       ? "minecraft:raw_" + ore.gt
-      : "gtceu:raw_" + ore.gt
+      : ns + ":raw_" + ore.gt
     var ig_dirty = "immersivegeology:dirty_crushed_ore_" + ore.ig
 
-    // IG → GT: GT Macerator with IE Crusher probability structure
+    // IG → GT: GT Compressor — same ratios as TFC→GT compression
     event.recipes.gtceu
-      .macerator("gregitas:ig_to_gt/poor_" + ore.ig + "_to_" + ore.gt)
-      .itemInputs("immersivegeology:poor_ore_" + ore.ig)
+      .compressor("gregitas:ig_to_gt/poor_" + ore.ig + "_to_" + ore.gt)
+      .itemInputs("6x immersivegeology:poor_ore_" + ore.ig)
       .itemOutputs(gt_crushed)
-      .chancedOutput(gt_crushed, 3300, 0)
-      .duration(400)
-      .EUt(2)
+      .duration(ore_conversion_duration)
+      .EUt(ore_conversion_eu)
 
     event.recipes.gtceu
-      .macerator("gregitas:ig_to_gt/normal_" + ore.ig + "_to_" + ore.gt)
-      .itemInputs("immersivegeology:normal_ore_" + ore.ig)
+      .compressor("gregitas:ig_to_gt/normal_" + ore.ig + "_to_" + ore.gt)
+      .itemInputs("4x immersivegeology:normal_ore_" + ore.ig)
       .itemOutputs(gt_crushed)
-      .chancedOutput(gt_crushed, 3300, 0)
-      .chancedOutput(gt_crushed, 1650, 0)
-      .duration(400)
-      .EUt(2)
+      .duration(ore_conversion_duration)
+      .EUt(ore_conversion_eu)
 
     event.recipes.gtceu
-      .macerator("gregitas:ig_to_gt/rich_" + ore.ig + "_to_" + ore.gt)
-      .itemInputs("immersivegeology:rich_ore_" + ore.ig)
+      .compressor("gregitas:ig_to_gt/rich_" + ore.ig + "_to_" + ore.gt)
+      .itemInputs("3x immersivegeology:rich_ore_" + ore.ig)
       .itemOutputs(gt_crushed)
-      .chancedOutput(gt_crushed, 3300, 0)
-      .chancedOutput(gt_crushed, 1650, 0)
-      .chancedOutput(gt_crushed, 1650, 0)
-      .duration(400)
-      .EUt(2)
+      .duration(ore_conversion_duration)
+      .EUt(ore_conversion_eu)
 
     // GT → IG: IE Crusher — 2× guaranteed + 10% chance of 1 more (2.1 average)
     event.custom({
@@ -99,12 +127,61 @@ let addIgGtConversions = (/** @type {Internal.RecipesEventJS} */ event) => {
     // GT → IG: Gravity Separator (water wash) — unlocks TFC ore → IG pipeline
     event.custom({
       type: "immersivegeology:gravity_separator",
-      input: { item: "gtceu:crushed_" + ore.gt + "_ore" },
+      input: { item: ns + ":crushed_" + ore.gt + "_ore" },
       result: { item: "immersivegeology:crushed_ore_" + ore.ig },
       byproduct: { item: "gtceu:stone_dust" },
       byproduct_chance: 0.33,
       water: 100,
       time: 100,
+    })
+  })
+
+  // TFC → IG: IE Crusher — IG's native ore processing odds per quality tier
+  tfc_ig_ores.forEach(function(ore) {
+    var ig_dirty = "immersivegeology:dirty_crushed_ore_" + ore.ig
+
+    var qualityConfigs = [
+      {
+        quality: "small",
+        secondaries: [],
+      },
+      {
+        quality: "poor",
+        secondaries: [
+          { chance: 0.33, output: { item: ig_dirty } },
+        ],
+      },
+      {
+        quality: "normal",
+        secondaries: [
+          { chance: 0.33,  output: { item: ig_dirty } },
+          { chance: 0.165, output: { item: ig_dirty } },
+        ],
+      },
+      {
+        quality: "rich",
+        secondaries: [
+          { chance: 0.33,  output: { item: ig_dirty } },
+          { chance: 0.165, output: { item: ig_dirty } },
+          { chance: 0.165, output: { item: ig_dirty } },
+        ],
+      },
+    ]
+
+    if (ore.sulfur) {
+      qualityConfigs[2].secondaries.push({ chance: 0.5, output: { item: "gtceu:sulfur_dust" } })
+      qualityConfigs[3].secondaries.push({ chance: 0.5, output: { item: "gtceu:sulfur_dust" } })
+    }
+
+    qualityConfigs.forEach(function(qc) {
+      event.custom({
+        type: "immersiveengineering:crusher",
+        energy: 6000,
+        input: { item: ore.mod + ":ore/" + qc.quality + "_" + ore.tfc },
+        result: { item: ig_dirty, count: 1 },
+        secondaries: qc.secondaries,
+        time: 100,
+      }).id("gregitas:tfc_to_ig/" + qc.quality + "_" + ore.tfc)
     })
   })
 }

--- a/kubejs/server_scripts/recipes/tfc_heating.js
+++ b/kubejs/server_scripts/recipes/tfc_heating.js
@@ -87,42 +87,51 @@ const replaceTFCHeatingAndCasting = (/** @type {Internal.RecipesEventJS} */ even
 // Immersive Geo ores fix 
 
   global.immGeoOres.forEach((ore) => {
+    if (ore.ore === "smithsonite") return
+
     event.custom({
       type: "tfc:heating",
-      ingredient: {
-        item: `immersivegeology:poor_ore_${ore.ore}`
-      },
-      result_fluid: {
-        fluid: `${ore.fluid}`,
-        amount: 16
-      },
+      ingredient: { item: `immersivegeology:poor_ore_${ore.ore}` },
+      result_fluid: { fluid: `${ore.fluid}`, amount: 24 },
       temperature: global.immGeoOresMelts[ore.ore]
     }).id(`gregitas:tfc/heating/immersive_geology/poor_${ore.ore}`)
-  
-  event.custom({
+
+    event.custom({
       type: "tfc:heating",
-      ingredient: {
-        item: `immersivegeology:normal_ore_${ore.ore}`
-      },
-      result_fluid: {
-        fluid: `${ore.fluid}`,
-        amount: 36
-      },
+      ingredient: { item: `immersivegeology:normal_ore_${ore.ore}` },
+      result_fluid: { fluid: `${ore.fluid}`, amount: 36 },
       temperature: global.immGeoOresMelts[ore.ore]
     }).id(`gregitas:tfc/heating/immersive_geology/normal_${ore.ore}`)
-  
-  event.custom({
+
+    event.custom({
       type: "tfc:heating",
       ingredient: { item: `immersivegeology:rich_ore_${ore.ore}` },
-      result_fluid: {
-        fluid: `${ore.fluid}`,   
-        amount: 48
-      },
+      result_fluid: { fluid: `${ore.fluid}`, amount: 48 },
       temperature: global.immGeoOresMelts[ore.ore]
     }).id(`gregitas:tfc/heating/immersive_geology/rich_${ore.ore}`)
-  
- 
   })
+
+  // Smithsonite: normal yield reduced
+  event.custom({
+    type: "tfc:heating",
+    ingredient: { item: "immersivegeology:poor_ore_smithsonite" },
+    result_fluid: { fluid: "tfc:metal/zinc", amount: 13 },
+    temperature: 420
+  }).id("gregitas:tfc/heating/immersive_geology/poor_smithsonite")
+
+  event.custom({
+    type: "tfc:heating",
+    ingredient: { item: "immersivegeology:normal_ore_smithsonite" },
+    result_fluid: { fluid: "tfc:metal/zinc", amount: 20 },
+    temperature: 420
+  }).id("gregitas:tfc/heating/immersive_geology/normal_smithsonite")
+
+  event.custom({
+    type: "tfc:heating",
+    ingredient: { item: "immersivegeology:rich_ore_smithsonite" },
+    result_fluid: { fluid: "tfc:metal/zinc", amount: 26 },
+    temperature: 420
+  }).id("gregitas:tfc/heating/immersive_geology/rich_smithsonite")
 
 
 

--- a/kubejs/server_scripts/tags/ig_vein_tags.js
+++ b/kubejs/server_scripts/tags/ig_vein_tags.js
@@ -1,0 +1,9 @@
+const addIGOresToTags = (/** @type {TagEvent.PlacedFeature} */ event) => {
+  // Register IG TFC cluster_vein placed_features with TFC's biome vein system.
+  global.igMineralData.minerals.forEach((mineral) => {
+    if (mineral.formations.length === 0) return
+    mineral.variants.forEach((variant) => {
+      event.add("tfc:in_biome/veins", `gravitas2:vein/ig_${mineral.id}_${variant.suffix}`)
+    })
+  })
+}

--- a/kubejs/startup_scripts/constants_startup.js
+++ b/kubejs/startup_scripts/constants_startup.js
@@ -390,6 +390,31 @@ global.gregVeins = [
 	}
   ]
 
+global.igBookData = [
+  { id: "chalcopyrite", name: "Chalcopyrite",    formations: ["IGNEOUS_INTRUSIVE"],                                    minY: -64, maxY: 256 },
+  { id: "cuprite",      name: "Cuprite",          formations: ["SEDIMENTARY", "IGNEOUS_EXTRUSIVE"],                    minY: -64, maxY: 256 },
+  { id: "chalcocite",   name: "Chalcocite",       formations: ["IGNEOUS_EXTRUSIVE"],                                   minY: -64, maxY: 200 },
+  { id: "acanthite",    name: "Acanthite",        formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -64, maxY: 212 },
+  { id: "apatite",      name: "Apatite",          formations: ["METAMORPHIC", "IGNEOUS_INTRUSIVE"],                    minY: -64, maxY: 212 },
+  { id: "fluorite",     name: "Fluorite",         formations: ["IGNEOUS_INTRUSIVE", "IGNEOUS_EXTRUSIVE"],              minY: -64, maxY: 220 },
+  { id: "pyrolusite",   name: "Pyrolusite",       formations: ["SEDIMENTARY"],                                         minY: -64, maxY: 112 },
+  { id: "ilmenite",     name: "Ilmenite",         formations: ["IGNEOUS_INTRUSIVE"],                                   minY:   5, maxY: 140 },
+  { id: "anatase",      name: "Anatase",          formations: ["IGNEOUS_INTRUSIVE", "IGNEOUS_EXTRUSIVE", "METAMORPHIC"], minY: 20, maxY: 180 },
+  { id: "cobaltite",    name: "Cobaltite",        formations: ["IGNEOUS_INTRUSIVE", "METAMORPHIC"],                    minY: -64, maxY:  72 },
+  { id: "millerite",    name: "Millerite",        formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -64, maxY: 120 },
+  { id: "molybdenite",  name: "Molybdenite",      formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -64, maxY: 212 },
+  { id: "scheelite",    name: "Scheelite",        formations: ["SEDIMENTARY", "IGNEOUS_INTRUSIVE"],                    minY: -32, maxY: 160 },
+  { id: "wolframite",   name: "Wolframite",       formations: ["IGNEOUS_EXTRUSIVE", "IGNEOUS_INTRUSIVE"],              minY:   0, maxY: 192 },
+  { id: "vanadinite",   name: "Vanadinite",       formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -32, maxY: 140 },
+  { id: "smithsonite",  name: "Smithsonite",      formations: ["SEDIMENTARY"],                                         minY:  30, maxY:  70 },
+  { id: "lead",         name: "Lead",             formations: ["SEDIMENTARY"],                                         minY:   0, maxY:  50 },
+  { id: "platinum",     name: "Platinum",         formations: ["IGNEOUS_INTRUSIVE"],                                   minY:  10, maxY:  80 },
+  { id: "zircon",       name: "Zircon",           formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -64, maxY: 200 },
+  { id: "thorianite",   name: "Thorianite",       formations: ["IGNEOUS_INTRUSIVE"],                                   minY: -32, maxY: 128 },
+  { id: "monazite",     name: "Monazite",         formations: ["SEDIMENTARY", "IGNEOUS_EXTRUSIVE"],                    minY:  12, maxY: 120 },
+  { id: "thorite",      name: "Thorite",          formations: ["IGNEOUS_INTRUSIVE"],                                   minY:   0, maxY:  80 },
+]
+
 /*
 GLOBAL FUEL DATA
 Currently used by:


### PR DESCRIPTION
### Recipes
- Removed IG -> GT Macerator recipes in favor of compressor recipes
- Removed TFC IE Addon Ore Crushing recipes in favor of TFC -> IG conversion recipes
- Replaced IE Sulfur with GT Sulfur in IG Sphalerite crushing recipe
- Added Compressor recipes that compress IG ore grades with the same ratios as the same TFC ore grades
- Added IE Crusher recipes to turn compatible TFC ores into IG dirty crushed ore with the same ratios as the same IG ore grades
- Added IG uraninite, chalcocite, cuprite, galena, acanthite, chromite, thorite, thorianite, smithsonite, and millerite heating recipes and data.

### World Gen
- Removed bugged, extremely rare, default IG ore gen from the overworld
- Added new tfc:cluster_vein ore gen for all IG ores that aren't already provided by TFC or an addon.

### Other
- Fixed IG ore names in the GT Prospectors
- Added IG ore information to the TFC handbook