### PR TITLE
Added GT Versions for IG materials

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -66,6 +66,7 @@
     "fluorite",
     "gold",
     "graphite",
+    "hafnium",
     "invar",
     "iridium",
     "iron",

--- a/kubejs/client_scripts/jei_hide/removals.js
+++ b/kubejs/client_scripts/jei_hide/removals.js
@@ -232,6 +232,7 @@ let hideItems = (/** @type {Internal.HideJEIEventJS}*/ event) => {
 
     // NuclearCraft machines replaced by GT equivalents
     event.hide('nuclearcraft:melter')
+    event.hide('immersivegeology:hammer_stone')
 }
 
 

--- a/kubejs/server_scripts/mods/immersive_engineering/recipes_add/ie_hop_graphite.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/recipes_add/ie_hop_graphite.js
@@ -5,14 +5,14 @@ var ieHopGraphiteChain = (/** @type {Internal.RecipesEventJS} */ event) => {
   // HCl is catalytic — equal amounts in and out
   event.recipes.gtceu.chemical_reactor("gregitas:ie/hop_graphite/acetylene")
     .inputFluids("gtceu:methane 2000", "gtceu:hydrochloric_acid 100")
-    .outputFluids("gregitas:acetylene 1000", "gtceu:hydrochloric_acid 100")
+    .outputFluids("gregitas_core:acetylene 1000", "gtceu:hydrochloric_acid 100")
     .EUt(HV).duration(200)
 
   // Step 2: Graphite + C₂H₂ → Pyrolitic Carbon (CVD)
   // Acetylene thermally decomposes onto graphite substrate: C₂H₂ → 2C + H₂
   event.recipes.gtceu.chemical_vapor_deposition("gregitas:ie/hop_graphite/cvd")
     .itemInputs("1x thoriumreactors:graphite_ingot")
-    .inputFluids("gregitas:acetylene 1000")
+    .inputFluids("gregitas_core:acetylene 1000")
     .itemOutputs("1x nuclearcraft:pyrolitic_carbon_ingot")
     .EUt(HV).duration(400)
 

--- a/kubejs/server_scripts/mods/immersive_geology/ig_constants.js
+++ b/kubejs/server_scripts/mods/immersive_geology/ig_constants.js
@@ -31,8 +31,8 @@ global.igMineralData = {
       id: "cuprite", value: "Cuprite",
       formations: ["SEDIMENTARY", "IGNEOUS_EXTRUSIVE"],
       variants: [
-        { suffix: "deep",    rarity: 55,  size: 30, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
-        { suffix: "surface", rarity: 50,  size: 25, density: 0.30, minY: 40,  maxY: 256, weights: [70, 25, 5]  },
+        { suffix: "deep",    rarity: 80,  size: 30, density: 0.45, minY: -64, maxY: 80,  weights: [35, 40, 25] },
+        { suffix: "surface", rarity: 75,  size: 25, density: 0.30, minY: 40,  maxY: 256, weights: [70, 25, 5]  },
       ],
     },
     // Used to make Osmium, so super rare in the overworld

--- a/kubejs/server_scripts/mods/immersive_geology/ig_removal.js
+++ b/kubejs/server_scripts/mods/immersive_geology/ig_removal.js
@@ -16,4 +16,7 @@ let igRecipesRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({id: "/^immersivegeology:prospector.*/"})
   event.remove({id: "immersivegeology:crafting/craft_titanium_concrete"})
   event.remove({id: "immersivegeology:crafting/craft_reinforced_concrete"})
+  event.remove({ id: "immersivegeology:crafting/craft_igtoolkit_0"})
+  event.remove({ id: "immersivegeology:crafting/craft_igtoolkit_1"})
+  event.remove({ id: "immersivegeology:crafting/craft_igtoolkit_2"})
 }

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_ebf_bridge.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_ebf_bridge.js
@@ -18,18 +18,20 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
   ]
   for (var i = 0; i < IG_EBF_GRITS.length; i++) {
     var row = IG_EBF_GRITS[i]
-    event.recipes.gtceu
+    var noGasRecipe = event.recipes.gtceu
       .electric_blast_furnace("gregitas:ig/ebf/" + row.id)
       .itemInputs("immersivegeology:" + row.input)
       .itemOutputs(row.out)
       .blastFurnaceTemp(row.temp).EUt(row.eut).duration(row.dur)
     if (row.gas) {
+      noGasRecipe.circuit(1)
       event.recipes.gtceu
         .electric_blast_furnace("gregitas:ig/ebf/" + row.id + "_" + row.gas)
         .itemInputs("immersivegeology:" + row.input)
         .itemOutputs(row.out)
         .inputFluids(Fluid.of("gtceu:" + row.gas, row.mb))
         .blastFurnaceTemp(row.temp).EUt(row.eut).duration(row.gasDur)
+        .circuit(2)
     }
   }
 
@@ -61,6 +63,7 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
     .blastFurnaceTemp(1900)
     .EUt(MV)
     .duration(900)
+    .circuit(1)
 
   event.recipes.gtceu
     .electric_blast_furnace("gregitas:ig/ebf/vanadium_oxide_nitrogen")
@@ -71,6 +74,7 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
     .blastFurnaceTemp(1900)
     .EUt(MV)
     .duration(600)
+    .circuit(2)
 
   // --- EBF: calcium slag (carbothermic reduction) ---------------------------
 
@@ -113,18 +117,20 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
   ]
   for (var i = 0; i < IG_EBF_CRYSTALS.length; i++) {
     var row = IG_EBF_CRYSTALS[i]
-    event.recipes.gtceu
+    var noGasRecipe = event.recipes.gtceu
       .electric_blast_furnace("gregitas:ig/ebf/crystal_" + row.mineral)
       .itemInputs("immersivegeology:crystal_" + row.mineral)
       .itemOutputs(row.out)
       .blastFurnaceTemp(row.temp).EUt(row.eut).duration(row.dur)
     if (row.gas) {
+      noGasRecipe.circuit(1)
       event.recipes.gtceu
         .electric_blast_furnace("gregitas:ig/ebf/crystal_" + row.mineral + "_" + row.gas)
         .itemInputs("immersivegeology:crystal_" + row.mineral)
         .itemOutputs(row.out)
         .inputFluids(Fluid.of("gtceu:" + row.gas, row.mb))
         .blastFurnaceTemp(row.temp).EUt(row.eut).duration(row.gasDur)
+        .circuit(2)
     }
   }
 
@@ -200,18 +206,20 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
   ]
   for (var i = 0; i < IG_BF_OXIDE_PELLETS.length; i++) {
     var row = IG_BF_OXIDE_PELLETS[i]
-    event.recipes.gtceu
+    var noGasRecipe = event.recipes.gtceu
       .electric_blast_furnace("gregitas:ig/ebf/oxide_pellet_" + row.mineral)
       .itemInputs("immersivegeology:oxide_pellet_" + row.mineral)
       .itemOutputs(row.out, row.slag || "immersiveengineering:slag")
       .blastFurnaceTemp(row.temp).EUt(row.eut || MV).duration(row.dur)
     if (row.gas) {
+      noGasRecipe.circuit(1)
       event.recipes.gtceu
         .electric_blast_furnace("gregitas:ig/ebf/oxide_pellet_" + row.mineral + "_" + row.gas)
         .itemInputs("immersivegeology:oxide_pellet_" + row.mineral)
         .itemOutputs(row.out, row.slag || "immersiveengineering:slag")
         .inputFluids(Fluid.of("gtceu:" + row.gas, row.mb))
         .blastFurnaceTemp(row.temp).EUt(row.eut || MV).duration(row.gasDur)
+        .circuit(2)
     }
   }
 

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_ebf_bridge.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_ebf_bridge.js
@@ -7,14 +7,14 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
   // --- EBF: high-tier metal grits / powders / oxides -----------------------
 
   var IG_EBF_GRITS = [
-    { id: "zirconium_grit", input: "grit_zirconium", out: "immersivegeology:ingot_zirconium", temp: 2100, eut: HV, dur: 1800, gasDur: 1200, gas: "helium", mb: 100 },
+    { id: "zirconium_grit", input: "grit_zirconium", out: "gtceu:hot_zirconium_ingot", temp: 2100, eut: HV, dur: 3872, gasDur: 2594, gas: "argon", mb: 50 },
     { id: "titanium_grit", input: "grit_titanium", out: "gtceu:hot_titanium_ingot", temp: 1941, eut: HV, dur: 1500, gasDur: 1005, gas: "helium", mb: 100 },
     { id: "silicon_grit", input: "grit_silicon", out: "gtceu:hot_silicon_ingot", temp: 2273, eut: MV, dur: 1272, gasDur: 900, gas: "nitrogen", mb: 100 },
     { id: "grit_magnesium", input: "grit_magnesium", out: "immersivegeology:ingot_magnesium", temp: 923, eut: LV, dur: 200 },
     { id: "grit_neodymium", input: "grit_neodymium", out: "gtceu:neodymium_ingot", temp: 1297, eut: MV, dur: 3735, gasDur: 2502, gas: "helium", mb: 100 },
     { id: "tungsten_powder", input: "powder_tungsten", out: "gtceu:hot_tungsten_ingot", temp: 3600, eut: EV, dur: 1206, gasDur: 804, gas: "helium", mb: 100 },
     { id: "grit_chromium",  input: "grit_chromium", out: "firmalife:metal/ingot/chromium",   temp: 2180, eut: MV, dur: 1768, gasDur: 1184, gas: "nitrogen", mb: 1000 },
-    { id: "grit_osmium",  input: "grit_osmium", out: "gtceu:hot_osmium_ingot",   temp: 4500, eut: LuV, dur: 1000, gasDur: 670, gas: "argon", mb: 50 },
+    { id: "grit_osmium",  input: "grit_osmium", out: "gtceu:hot_osmium_ingot", temp: 4500, eut: LuV, dur: 1000, gasDur: 670, gas: "argon", mb: 50 },
   ]
   for (var i = 0; i < IG_EBF_GRITS.length; i++) {
     var row = IG_EBF_GRITS[i]
@@ -106,7 +106,7 @@ var igEbfBridge = (/** @type {Internal.RecipesEventJS} */ event) => {
   // --- EBF: crystal routes -------------------------------------------------
 
   var IG_EBF_CRYSTALS = [
-    { mineral: "zirconium", out: "immersivegeology:ingot_zirconium", temp: 2100, eut: HV, dur: 1800, gasDur: 1200, gas: "helium", mb: 100 },
+    { mineral: "zirconium", out: "gtceu:hot_zirconium_ingot",        temp: 2100, eut: HV, dur: 3872, gasDur: 2594, gas: "argon", mb: 50 },
     { mineral: "neodymium", out: "gtceu:neodymium_ingot",            temp: 1297, eut: MV, dur: 3735, gasDur: 2502, gas: "helium", mb: 100 },
     { mineral: "chromium",  out: "firmalife:metal/ingot/chromium",   temp: 2180, eut: MV, dur: 1768, gasDur: 1184, gas: "nitrogen", mb: 1000 },
     { mineral: "magnesium", out: "immersivegeology:ingot_magnesium", temp: 923, eut: LV, dur: 200 },

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_blocks_nuggets.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_blocks_nuggets.js
@@ -12,16 +12,6 @@ var IG_BLOCK_NUGGET_MATS = [
     blockFluid: "gtceu:magnesium",
     nuggetFluid: "gtceu:magnesium",
   },
-  {
-    material:   "zirconium",
-    ingotTag:   "#forge:ingots/zirconium",
-    nuggetTag:  "#forge:nuggets/zirconium",
-    blockItem:  "immersivegeology:storage_block_zirconium",
-    ingotItem:  "immersivegeology:ingot_zirconium",
-    nuggetItem: "immersivegeology:nugget_zirconium",
-    blockFluid: "nuclearcraft:zirconium",
-    nuggetFluid: "nuclearcraft:zirconium",
-  },
 ]
 
 var igGtBlocksNuggets = (/** @type {Internal.RecipesEventJS} */ event) => {

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_conversion.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_gt_conversion.js
@@ -40,7 +40,17 @@ var ig_gt_ores = [
   { ig: "chalcocite",   gt: "chalcocite"       },
   { ig: "apatite",      gt: "apatite"          },
   { ig: "monazite",     gt: "monazite"         },
-  { ig: "fluorite",     gt: "fluorite",  ns: "gcyr" },
+  { ig: "fluorite",     gt: "fluorite",    ns: "gcyr" },
+  { ig: "zircon",       gt: "zircon",      ns: "gregitas_core" },
+  { ig: "wolframite",   gt: "wolframite",  ns: "gregitas_core" },
+  { ig: "smithsonite",  gt: "smithsonite", ns: "gregitas_core" },
+  { ig: "vanadinite",   gt: "vanadinite",  ns: "gregitas_core" },
+  { ig: "millerite",    gt: "millerite",   ns: "gregitas_core" },
+  { ig: "acanthite",    gt: "acanthite",   ns: "gregitas_core" },
+  { ig: "cuprite",      gt: "cuprite",     ns: "gregitas_core" },
+  { ig: "thorianite",   gt: "thorianite",  ns: "gregitas_core" },
+  { ig: "thorite",      gt: "thorite",     ns: "gregitas_core" },
+  { ig: "anatase",      gt: "anatase",     ns: "gregitas_core" },
 ]
 
 var tfc_ig_ores = [

--- a/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_misc_recipes.js
+++ b/kubejs/server_scripts/mods/immersive_geology/recipes_add/ig_misc_recipes.js
@@ -20,6 +20,7 @@ var igMiscRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
     { gt: "tungsten_block",         ig: "storage_block_tungsten"},
     { gt: "vanadium_block",         ig: "storage_block_vanadium"},
     { gt: "zinc_block",             ig: "storage_block_zinc"},
+    { gt: "zirconium_block",        ig: "storage_block_zirconium"},
     { gt: "tungsten_carbide_block", ig: "storage_block_tungsten_carbide"},
   ]
 

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_macerator.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_macerator.js
@@ -44,6 +44,8 @@ const NC_MA_EXCLUDED_PATHS = {
   uranium_chunk:    true,
   boron_chunk:      true,
   ingots_aluminum:  true,
+  ingots_zirconium: true,
+  ingots_hafnium:   true,
 }
 
 // Ingot input bypass: NC ingots for these materials are always bridged to GT macerator,

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_pressurizer.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_pressurizer.js
@@ -50,7 +50,8 @@ var NC_PR_OTHER_DURATION = 300
 // --- Skip list ---------------------------------------------------------------
 
 var NC_PR_SKIP_IDS = [
-  "dusts_diamond", "ingots_graphite", "dusts_obsidian", "dusts_quartz", "ingots_silicon_carbide"
+  "dusts_diamond", "ingots_graphite", "dusts_obsidian", "dusts_quartz", "ingots_silicon_carbide",
+  "ingots_zirconium"
 ]
 
 // Fluid overrides: material → concrete fluid ID (no amount suffix)

--- a/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_solidifier.js
+++ b/kubejs/server_scripts/mods/nuclearcraft/bridges/nc_to_gt_solidifier.js
@@ -34,6 +34,7 @@ const GT_IF_INGOT_MB = 144
 // NC ingot_former recipe paths (everything after "nuclearcraft:ingot_former/") to skip.
 const NC_IF_EXCLUDED_PATHS = {
   "boron_arsenide": true,  // GT handles this via chemical reactor
+  "molten_zirconium": true,
 }
 
 // Hardcoded overrides for NC forge-tag inputs that should resolve to a specific

--- a/kubejs/server_scripts/recipes/add.js
+++ b/kubejs/server_scripts/recipes/add.js
@@ -357,7 +357,9 @@ const gtVacuumShit = [
   "stellite_100",
   "titanium_carbide",
   "titanium_tungsten_carbide",
-  "hastelloy_c_276"
+  "hastelloy_c_276",
+  "zirconium",
+  "hafnium",
 ]
 
 const thermalDepositsMap = {

--- a/kubejs/startup_scripts/registry/fluids.js
+++ b/kubejs/startup_scripts/registry/fluids.js
@@ -12,11 +12,4 @@ let registerFluids = (/** @type {Registry.Fluid} */ event) => {
 
   // Leaded glass fluid for GT-DFC integration
   event.create("gregitas:leaded_glass").thinTexture(0x938e98).displayName("Molten Leaded Glass")
-
-  // IE HOP Graphite chain
-  event.create("gregitas:acetylene")
-    .stillTexture("gtceu:block/material_sets/dull/gas")
-    .flowingTexture("gtceu:block/material_sets/dull/gas")
-    .color(0xd4d4d4)
-    .displayName("Acetylene")
 }


### PR DESCRIPTION
Requires https://github.com/AllTheMods/gregitas-core/pull/29

- Added new ore types Acanthite, Anatase, Cuprite, Millerite, Smithsonite, Thorianite, Thorite, Vanadite, Wolframite, and Zircon They do not generate and are just for IG -> GT ore conversion
- Moved Acetylene (for HOP Graphite crafting chain) from KubeJS to gregitas-core
- Updated code for new Hafnium gtceu material from core
- Updated code for new Zirconium gtceu material from core
- Made Cuprite somewhat rarer as it is a less common copper ore IRL
- Hid stone hammer, only used to form the disabled blast furnace and bloomery
- Removed default recipes for bronze and stainless steel hammer in favor of custom recipe