### PR TITLE
IE antennae + interface connector fix

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
@@ -917,8 +917,11 @@
 						items: [
 							{
 								Count: 1b
-								id: "gtceu:steam_miner"
+								id: "gtceu:lp_steam_miner"
 							}
+							{
+								Count: 1b
+								id: "gtceu:hp_steam_miner"
 							{
 								Count: 1b
 								id: "gtceu:lv_miner"

--- a/kubejs/server_scripts/mods/immersive_engineering/ie_removal.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/ie_removal.js
@@ -47,6 +47,8 @@ let ieRecipesRemoval = (/** @type {Internal.RecipesEventJS} */ event) => {
   event.remove({ id: "createaddition:compat/immersiveengineering/item_application/kiln_brick"})
   event.remove({ id: "createaddition:compat/immersiveengineering/item_application/kiln_brick_using_deployer"})
   event.remove({ id: "immersiveengineering:blueprint/circuit_board"})
+  event.remove({ id: "immersiveengineering:crafting/connector_bundled"})
+  event.remove({ id: "immersiveengineering:crafting/toolupgrade_powerpack_antenna"})
 
   // IE Crusher: c:raw_materials/* → dust conflicts with IG↔GT raw ore conversion
   event.remove({ id: /^immersiveengineering:crusher\/raw_ore_.*/ })

--- a/kubejs/server_scripts/mods/immersive_engineering/recipes_add/ie_misc.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/recipes_add/ie_misc.js
@@ -59,4 +59,16 @@ var ieMiscRecipes = (/** @type {Internal.RecipesEventJS} */ event) => {
     b: "gtceu:phenolic_printed_circuit_board",
     w: "#forge:fine_wires/aluminium"
   })
+  
+  event.shaped("immersiveengineering:connector_bundled", [" w ", "wcw"," w "], {
+    c: "immersiveengineering:connector_redstone",
+    w: "#forge:fine_wires/aluminium"
+  })
+
+  event.shaped("immersiveengineering:toolupgrade_powerpack_antenna", ["www", "rww","c  "], {
+    c: "immersiveengineering:connector_lv",
+    w: "#forge:fine_wires/aluminium",
+    r: "#forge:rods/aluminium"
+  })
+
 }


### PR DESCRIPTION
Base IE recipe calls for #forge:wires/aluminum
This tag is empty, only valid Al wires in pack are GT variants.
Replaceinput is not able to hit these recipes as tag is empty

- removed base recipe
- re added exact shaped pattern in misc, with GT fine al wires.

This method has been done prior for immersiveengineering:component_electronic_advanced