### PR TITLE
Add both missing steam miners to steam miner quest

### DIFF
--- a/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
+++ b/config/ftbquests/quests/chapters/gravitaschapterssteamtitle.snbt
@@ -917,7 +917,11 @@
 						items: [
 							{
 								Count: 1b
-								id: "gtceu:steam_miner"
+								id: "gtceu:hp_steam_miner"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lp_steam_miner"
 							}
 							{
 								Count: 1b


### PR DESCRIPTION
Old entry had or filter for gtceu:steam_miner
Item no longer exists
Updated to accept gtceu:lp_steam_miner gtceu:hp_steam_miner

Validated in singleplayer :D